### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,4 +38,4 @@ jobs:
         run: composer update --prefer-dist --no-interaction --no-suggest
 
       - name: Run tests
-        run: ./vendor/bin/phpunit
+        run: ./vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,11 @@
         "nunomaduro/collision": "^5.0",
         "nunomaduro/larastan": "^1.0.1",
         "nunomaduro/patrol": "^1.0",
-        "phpunit/phpunit": "^9.3.3",
         "roave/security-advisories": "dev-latest",
         "spatie/laravel-ray": "^1.17",
-        "spatie/test-time": "^1.2"
+        "spatie/test-time": "^1.2",
+        "pestphp/pest": "^1.20",
+        "pestphp/pest-plugin-laravel": "^1.1"
     },
     "config": {
         "optimize-autoloader": true,

--- a/tests/Feature/Actions/ImportVideoActionTest.php
+++ b/tests/Feature/Actions/ImportVideoActionTest.php
@@ -22,5 +22,5 @@ it('adds a channel id if channel already given', function () {
     $importedStream = (new ImportVideoAction())->handle($youTubeId);
 
     // Assert
-    $this->assertEquals($channel->id, $importedStream->channel_id);
+    expect($importedStream->channel_id)->toEqual($channel->id);
 });

--- a/tests/Feature/Actions/ImportVideoActionTest.php
+++ b/tests/Feature/Actions/ImportVideoActionTest.php
@@ -1,32 +1,26 @@
 <?php
 
-namespace Tests\Feature\Actions;
-
 use App\Actions\ImportVideoAction;
 use App\Models\Channel;
 use Illuminate\Support\Facades\Http;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-class ImportVideoActionTest extends TestCase
-{
-    use YouTubeResponses;
+uses(TestCase::class);
+uses(YouTubeResponses::class);
 
-    /** @test */
-    public function it_adds_a_channel_id_if_channel_already_given(): void
-    {
-        Http::fake([
-            '*videos*' => Http::response($this->singleVideoResponse()),
-        ]);
+it('adds a channel id if channel already given', function () {
+    Http::fake([
+        '*videos*' => Http::response($this->singleVideoResponse()),
+    ]);
 
-        // Arrange
-        $youTubeId = 'gzqJZQyfkaI';
-        $channel = Channel::factory()->create(['platform_id' => 'UCNlUCA4VORBx8X-h-rXvXEg']);
+    // Arrange
+    $youTubeId = 'gzqJZQyfkaI';
+    $channel = Channel::factory()->create(['platform_id' => 'UCNlUCA4VORBx8X-h-rXvXEg']);
 
-        // Act
-        $importedStream = (new ImportVideoAction())->handle($youTubeId);
+    // Act
+    $importedStream = (new ImportVideoAction())->handle($youTubeId);
 
-        // Assert
-        $this->assertEquals($channel->id, $importedStream->channel_id);
-    }
-}
+    // Assert
+    $this->assertEquals($channel->id, $importedStream->channel_id);
+});

--- a/tests/Feature/Actions/ImportVideoActionTest.php
+++ b/tests/Feature/Actions/ImportVideoActionTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-uses(TestCase::class);
 uses(YouTubeResponses::class);
 
 it('adds a channel id if channel already given', function () {

--- a/tests/Feature/Actions/SortStreamsByDateActionTest.php
+++ b/tests/Feature/Actions/SortStreamsByDateActionTest.php
@@ -1,59 +1,52 @@
 <?php
 
-namespace Tests\Feature\Actions;
-
 use App\Actions\SortStreamsByDateAction;
 use App\Models\Stream;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-class SortStreamsByDateActionTest extends TestCase
-{
-    /** @test */
-    public function it_groups_streams_by_date(): void
-    {
-        // Arrange
-        $streams = Stream::factory()->count(3)
-            ->state(new Sequence(
-                ['scheduled_start_time' => Carbon::today()],
-                ['scheduled_start_time' => Carbon::tomorrow()],
-                ['scheduled_start_time' => Carbon::tomorrow()->addDay()],
-            ))->create();
+uses(TestCase::class);
 
-        $prepareStreamsAction = new SortStreamsByDateAction;
+it('groups streams by date', function () {
+    // Arrange
+    $streams = Stream::factory()->count(3)
+        ->state(new Sequence(
+            ['scheduled_start_time' => Carbon::today()],
+            ['scheduled_start_time' => Carbon::tomorrow()],
+            ['scheduled_start_time' => Carbon::tomorrow()->addDay()],
+        ))->create();
 
-        // Act
-        $preparedStreams = $prepareStreamsAction->handle($streams);
+    $prepareStreamsAction = new SortStreamsByDateAction;
 
-        // Assert
-        $this->assertEquals('Today', $preparedStreams->keys()[0]);
-        $this->assertEquals('Tomorrow', $preparedStreams->keys()[1]);
-        $this->assertEquals(Carbon::tomorrow()->addDay()->format('D, M jS Y'), $preparedStreams->keys()[2]);
-    }
+    // Act
+    $preparedStreams = $prepareStreamsAction->handle($streams);
 
-    /** @test */
-    public function it_orders_streams_from_current_to_upcoming(): void
-    {
-        $this->travelTo(Carbon::parse('2021-06-11 00:00'));
+    // Assert
+    $this->assertEquals('Today', $preparedStreams->keys()[0]);
+    $this->assertEquals('Tomorrow', $preparedStreams->keys()[1]);
+    $this->assertEquals(Carbon::tomorrow()->addDay()->format('D, M jS Y'), $preparedStreams->keys()[2]);
+});
 
-        // Arrange
-        $streams = Stream::factory()->count(3)
-            ->state(new Sequence(
-                ['scheduled_start_time' => Carbon::today()],
-                ['scheduled_start_time' => Carbon::tomorrow()],
-                ['scheduled_start_time' => Carbon::tomorrow()->addDay()],
-            ))->create();
+it('orders streams from current to upcoming', function () {
+    $this->travelTo(Carbon::parse('2021-06-11 00:00'));
 
-        $prepareStreamsAction = new SortStreamsByDateAction;
+    // Arrange
+    $streams = Stream::factory()->count(3)
+        ->state(new Sequence(
+            ['scheduled_start_time' => Carbon::today()],
+            ['scheduled_start_time' => Carbon::tomorrow()],
+            ['scheduled_start_time' => Carbon::tomorrow()->addDay()],
+        ))->create();
 
-        // Act
-        $preparedStreams = $prepareStreamsAction->handle($streams);
+    $prepareStreamsAction = new SortStreamsByDateAction;
 
-        $this->assertEquals([
-            'Today',
-            'Tomorrow',
-            'Sun, Jun 13th 2021',
-        ], $preparedStreams->keys()->toArray());
-    }
-}
+    // Act
+    $preparedStreams = $prepareStreamsAction->handle($streams);
+
+    $this->assertEquals([
+        'Today',
+        'Tomorrow',
+        'Sun, Jun 13th 2021',
+    ], $preparedStreams->keys()->toArray());
+});

--- a/tests/Feature/Actions/SortStreamsByDateActionTest.php
+++ b/tests/Feature/Actions/SortStreamsByDateActionTest.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('groups streams by date', function () {
     // Arrange

--- a/tests/Feature/Actions/SortStreamsByDateActionTest.php
+++ b/tests/Feature/Actions/SortStreamsByDateActionTest.php
@@ -23,9 +23,9 @@ it('groups streams by date', function () {
     $preparedStreams = $prepareStreamsAction->handle($streams);
 
     // Assert
-    $this->assertEquals('Today', $preparedStreams->keys()[0]);
-    $this->assertEquals('Tomorrow', $preparedStreams->keys()[1]);
-    $this->assertEquals(Carbon::tomorrow()->addDay()->format('D, M jS Y'), $preparedStreams->keys()[2]);
+    expect($preparedStreams->keys()[0])->toEqual('Today');
+    expect($preparedStreams->keys()[1])->toEqual('Tomorrow');
+    expect($preparedStreams->keys()[2])->toEqual(Carbon::tomorrow()->addDay()->format('D, M jS Y'));
 });
 
 it('orders streams from current to upcoming', function () {

--- a/tests/Feature/Actions/Submission/ApproveStreamActionTest.php
+++ b/tests/Feature/Actions/Submission/ApproveStreamActionTest.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Mail;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-uses(TestCase::class);
 uses(YouTubeResponses::class);
 
 beforeEach(function () {

--- a/tests/Feature/Actions/Submission/ApproveStreamActionTest.php
+++ b/tests/Feature/Actions/Submission/ApproveStreamActionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Actions\Submission;
-
 use App\Actions\Submission\ApproveStreamAction;
 use App\Console\Commands\ImportChannelsForStreamsCommand;
 use App\Mail\StreamApprovedMail;
@@ -13,112 +11,95 @@ use Illuminate\Support\Facades\Mail;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-class ApproveStreamActionTest extends TestCase
-{
-    use YouTubeResponses;
+uses(TestCase::class);
+uses(YouTubeResponses::class);
 
-    protected ApproveStreamAction $approveStreamAction;
+beforeEach(function () {
+    Mail::fake();
+    Http::fake(fn() => Http::response($this->videoResponse()));
+    $this->approveStreamAction = app(ApproveStreamAction::class);
+});
 
-    public function setUp(): void
-    {
-        parent::setUp();
+test('the action can approve a stream', function () {
+    // Arrange
+    $stream = Stream::factory()
+        ->notApproved()
+        ->create([
+            'submitted_by_email' => 'john@example.com',
+        ]);
 
-        Mail::fake();
-        Http::fake(fn() => Http::response($this->videoResponse()));
-        $this->approveStreamAction = app(ApproveStreamAction::class);
-    }
+    Artisan::spy();
 
-    /** @test */
-    public function the_action_can_approve_a_stream(): void
-    {
-        // Arrange
-        $stream = Stream::factory()
-            ->notApproved()
-            ->create([
-                'submitted_by_email' => 'john@example.com',
-            ]);
+    // Act
+    $this->approveStreamAction->handle($stream);
 
-        Artisan::spy();
+    // Assert
+    $stream = $stream->fresh();
+    $this->assertNotNull($stream->approved_at);
 
-        // Act
-        $this->approveStreamAction->handle($stream);
+    Mail::assertQueued(fn(StreamApprovedMail $mail) => $mail->hasTo($stream->submitted_by_email));
+});
 
-        // Assert
-        $stream = $stream->fresh();
-        $this->assertNotNull($stream->approved_at);
+test('the action calls the import channel command', function () {
+    // Arrange
+    $stream = Stream::factory()
+        ->notApproved()
+        ->create();
 
-        Mail::assertQueued(fn(StreamApprovedMail $mail) => $mail->hasTo($stream->submitted_by_email));
-    }
+    Artisan::spy();
 
-    /** @test */
-    public function the_action_calls_the_import_channel_command(): void
-    {
-        // Arrange
-        $stream = Stream::factory()
-            ->notApproved()
-            ->create();
+    // Act
+    $this->approveStreamAction->handle($stream);
 
-        Artisan::spy();
+    // Assert
+    Artisan::shouldHaveReceived('call')->once()->with(ImportChannelsForStreamsCommand::class, ['stream' => $stream]);
+});
 
-        // Act
-        $this->approveStreamAction->handle($stream);
+test('the action calls does not import a channel if channel already given', function () {
+    // Arrange
+    $stream = Stream::factory()
+        ->withChannel()
+        ->notApproved()
+        ->create();
 
-        // Assert
-        Artisan::shouldHaveReceived('call')->once()->with(ImportChannelsForStreamsCommand::class, ['stream' => $stream]);
-    }
+    Artisan::spy();
 
-    /** @test */
-    public function the_action_calls_does_not_import_a_channel_if_channel_already_given(): void
-    {
-        // Arrange
-        $stream = Stream::factory()
-            ->withChannel()
-            ->notApproved()
-            ->create();
+    // Assert
+    Artisan::shouldNotReceive('call')->with(ImportChannelsForStreamsCommand::class, ['stream' => $stream]);
 
-        Artisan::spy();
+    // Act
+    $this->approveStreamAction->handle($stream);
+});
 
-        // Assert
-        Artisan::shouldNotReceive('call')->with(ImportChannelsForStreamsCommand::class, ['stream' => $stream]);
+it('will not send a mail for a link that was already approved', function () {
+    // Arrange
+    $stream = Stream::factory()
+        ->approved()
+        ->create([
+            'submitted_by_email' => 'john@example.com',
+        ]);
 
-        // Act
-        $this->approveStreamAction->handle($stream);
-    }
+    // Act
+    $this->approveStreamAction->handle($stream);
 
-    /** @test */
-    public function it_will_not_send_a_mail_for_a_link_that_was_already_approved(): void
-    {
-        // Arrange
-        $stream = Stream::factory()
-            ->approved()
-            ->create([
-                'submitted_by_email' => 'john@example.com',
-            ]);
+    // Assert
+    Mail::assertNothingQueued();
+});
 
-        // Act
-        $this->approveStreamAction->handle($stream);
+it('updates stream before approving it', function () {
+    // Arrange
+    $stream = Stream::factory()
+        ->upcoming()
+        ->notApproved()
+        ->create([
+            'submitted_by_email' => 'john@example.com',
+        ]);
+    Artisan::spy();
 
-        // Assert
-        Mail::assertNothingQueued();
-    }
+    // Act
+    $this->approveStreamAction->handle($stream);
 
-    /** @test */
-    public function it_updates_stream_before_approving_it(): void
-    {
-        // Arrange
-        $stream = Stream::factory()
-            ->upcoming()
-            ->notApproved()
-            ->create([
-                'submitted_by_email' => 'john@example.com',
-            ]);
-        Artisan::spy();
-
-        // Act
-        $this->approveStreamAction->handle($stream);
-
-        // Assert
-        $stream->refresh();
-        $this->assertEquals(StreamData::STATUS_FINISHED, $stream->status);
-    }
-}
+    // Assert
+    $stream->refresh();
+    $this->assertEquals(StreamData::STATUS_FINISHED, $stream->status);
+});

--- a/tests/Feature/Actions/Submission/ApproveStreamActionTest.php
+++ b/tests/Feature/Actions/Submission/ApproveStreamActionTest.php
@@ -101,5 +101,5 @@ it('updates stream before approving it', function () {
 
     // Assert
     $stream->refresh();
-    $this->assertEquals(StreamData::STATUS_FINISHED, $stream->status);
+    expect($stream->status)->toEqual(StreamData::STATUS_FINISHED);
 });

--- a/tests/Feature/Actions/Submission/RejectStreamActionTest.php
+++ b/tests/Feature/Actions/Submission/RejectStreamActionTest.php
@@ -23,5 +23,5 @@ test('the action sends rejection mail', function () {
 
     // Assert
     Mail::assertQueued(fn(StreamRejectedMail $mail) => $mail->hasTo($stream->submitted_by_email));
-    $this->assertFalse($stream->refresh()->isApproved());
+    expect($stream->refresh()->isApproved())->toBeFalse();
 });

--- a/tests/Feature/Actions/Submission/RejectStreamActionTest.php
+++ b/tests/Feature/Actions/Submission/RejectStreamActionTest.php
@@ -1,32 +1,27 @@
 <?php
 
-namespace Tests\Feature\Actions\Submission;
-
 use App\Actions\Submission\RejectStreamAction;
 use App\Mail\StreamRejectedMail;
 use App\Models\Stream;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
-class RejectStreamActionTest extends TestCase
-{
-    /** @test */
-    public function the_action_sends_rejection_mail(): void
-    {
-        // Arrange
-        Mail::fake();
-        $stream = Stream::factory()
-            ->notApproved()
-            ->create([
-                'submitted_by_email' => 'john@example.com',
-            ]);
+uses(TestCase::class);
 
-        // Act
-        $action = app(RejectStreamAction::class);
-        $action->handle($stream);
+test('the action sends rejection mail', function () {
+    // Arrange
+    Mail::fake();
+    $stream = Stream::factory()
+        ->notApproved()
+        ->create([
+            'submitted_by_email' => 'john@example.com',
+        ]);
 
-        // Assert
-        Mail::assertQueued(fn(StreamRejectedMail $mail) => $mail->hasTo($stream->submitted_by_email));
-        $this->assertFalse($stream->refresh()->isApproved());
-    }
-}
+    // Act
+    $action = app(RejectStreamAction::class);
+    $action->handle($stream);
+
+    // Assert
+    Mail::assertQueued(fn(StreamRejectedMail $mail) => $mail->hasTo($stream->submitted_by_email));
+    $this->assertFalse($stream->refresh()->isApproved());
+});

--- a/tests/Feature/Actions/Submission/RejectStreamActionTest.php
+++ b/tests/Feature/Actions/Submission/RejectStreamActionTest.php
@@ -6,7 +6,6 @@ use App\Models\Stream;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('the action sends rejection mail', function () {
     // Arrange

--- a/tests/Feature/Actions/Submission/SubmitStreamActionTest.php
+++ b/tests/Feature/Actions/Submission/SubmitStreamActionTest.php
@@ -29,9 +29,9 @@ it('can store a stream', function () {
     $stream = Stream::firstWhere('youtube_id', $this->youTubeId);
     $this->assertNotNull($stream);
 
-    $this->assertFalse($stream->isApproved());
-    $this->assertEquals('john@example.com', $stream->submitted_by_email);
-    $this->assertEquals('de', $stream->language_code);
+    expect($stream->isApproved())->toBeFalse();
+    expect($stream->submitted_by_email)->toEqual('john@example.com');
+    expect($stream->language_code)->toEqual('de');
 
     Mail::assertQueued(fn(StreamSubmittedMail $mail) => $mail->hasTo('christoph@christoph-rumpel.com'));
 });

--- a/tests/Feature/Actions/Submission/SubmitStreamActionTest.php
+++ b/tests/Feature/Actions/Submission/SubmitStreamActionTest.php
@@ -8,7 +8,6 @@ use App\Services\YouTube\StreamData;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can store a stream', function () {
     // Arrange

--- a/tests/Feature/Actions/Submission/SubmitStreamActionTest.php
+++ b/tests/Feature/Actions/Submission/SubmitStreamActionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Actions\Submission;
-
 use App\Actions\Submission\SubmitStreamAction;
 use App\Facades\YouTube;
 use App\Mail\StreamSubmittedMail;
@@ -10,35 +8,30 @@ use App\Services\YouTube\StreamData;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
-class SubmitStreamActionTest extends TestCase
-{
-    private string $youTubeId = '1234';
+uses(TestCase::class);
 
-    /** @test */
-    public function it_can_store_a_stream(): void
-    {
-        // Arrange
-        Mail::fake();
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(
-                    videoId: $this->youTubeId,
-                ),
-            ]));
+it('can store a stream', function () {
+    // Arrange
+    Mail::fake();
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(
+                videoId: $this->youTubeId,
+            ),
+        ]));
 
-        // Act
-        $action = app(SubmitStreamAction::class);
-        $action->handle($this->youTubeId, 'de', 'john@example.com');
+    // Act
+    $action = app(SubmitStreamAction::class);
+    $action->handle($this->youTubeId, 'de', 'john@example.com');
 
-        // Assert
-        $stream = Stream::firstWhere('youtube_id', $this->youTubeId);
-        $this->assertNotNull($stream);
+    // Assert
+    $stream = Stream::firstWhere('youtube_id', $this->youTubeId);
+    $this->assertNotNull($stream);
 
-        $this->assertFalse($stream->isApproved());
-        $this->assertEquals('john@example.com', $stream->submitted_by_email);
-        $this->assertEquals('de', $stream->language_code);
+    $this->assertFalse($stream->isApproved());
+    $this->assertEquals('john@example.com', $stream->submitted_by_email);
+    $this->assertEquals('de', $stream->language_code);
 
-        Mail::assertQueued(fn(StreamSubmittedMail $mail) => $mail->hasTo('christoph@christoph-rumpel.com'));
-    }
-}
+    Mail::assertQueued(fn(StreamSubmittedMail $mail) => $mail->hasTo('christoph@christoph-rumpel.com'));
+});

--- a/tests/Feature/Actions/UpdateStreamActionTest.php
+++ b/tests/Feature/Actions/UpdateStreamActionTest.php
@@ -6,7 +6,6 @@ use App\Services\YouTube\StreamData;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->stream = Stream::factory()

--- a/tests/Feature/Actions/UpdateStreamActionTest.php
+++ b/tests/Feature/Actions/UpdateStreamActionTest.php
@@ -1,65 +1,53 @@
 <?php
 
-namespace Tests\Feature\Actions;
-
 use App\Actions\UpdateStreamAction;
 use App\Models\Stream;
 use App\Services\YouTube\StreamData;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-class UpdateStreamActionTest extends TestCase
-{
-    protected StreamData $streamData;
+uses(TestCase::class);
 
-    protected Stream $stream;
+beforeEach(function () {
+    $this->stream = Stream::factory()
+        ->upcoming()
+        ->create([
+            'youtube_id' => '1234',
+            'title' => 'old title',
+            'description' => 'old desc',
+            'thumbnail_url' => 'old thumbnail url',
+            'scheduled_start_time' => Carbon::tomorrow(),
+            'actual_start_time' => null,
+            'actual_end_time' => null,
+            'language_code' => 'en',
+        ]);
 
-    public function setUp(): void
-    {
-        parent::setUp();
+    $this->streamData = new StreamData(
+        videoId: '1234',
+        title: 'new title',
+        channelId: '5678',
+        channelTitle: 'new channel title',
+        description: 'new desc',
+        thumbnailUrl: 'new thumbnail url',
+        publishedAt: Carbon::yesterday(),
+        plannedStart: Carbon::yesterday(),
+        actualStartTime: Carbon::yesterday(),
+        actualEndTime: Carbon::yesterday()->addHour(),
+        status: StreamData::STATUS_FINISHED
+    );
+});
 
-        $this->stream = Stream::factory()
-            ->upcoming()
-            ->create([
-                'youtube_id' => '1234',
-                'title' => 'old title',
-                'description' => 'old desc',
-                'thumbnail_url' => 'old thumbnail url',
-                'scheduled_start_time' => Carbon::tomorrow(),
-                'actual_start_time' => null,
-                'actual_end_time' => null,
-                'language_code' => 'en',
-            ]);
+it('updates a stream', function () {
+    // Act
+    $updatedStream = (new UpdateStreamAction)->handle($this->stream, $this->streamData);
 
-        $this->streamData = new StreamData(
-            videoId: '1234',
-            title: 'new title',
-            channelId: '5678',
-            channelTitle: 'new channel title',
-            description: 'new desc',
-            thumbnailUrl: 'new thumbnail url',
-            publishedAt: Carbon::yesterday(),
-            plannedStart: Carbon::yesterday(),
-            actualStartTime: Carbon::yesterday(),
-            actualEndTime: Carbon::yesterday()->addHour(),
-            status: StreamData::STATUS_FINISHED
-        );
-    }
-
-    /** @test */
-    public function it_updates_a_stream(): void
-    {
-        // Act
-        $updatedStream = (new UpdateStreamAction)->handle($this->stream, $this->streamData);
-
-        // Assert
-        $this->assertEquals($this->stream->id, $updatedStream->id);
-        $this->assertEquals($this->streamData->title, $updatedStream->title);
-        $this->assertEquals($this->streamData->description, $updatedStream->description);
-        $this->assertEquals($this->streamData->thumbnailUrl, $updatedStream->thumbnail_url);
-        $this->assertEquals($this->streamData->plannedStart, $updatedStream->scheduled_start_time);
-        $this->assertEquals($this->streamData->actualStartTime, $updatedStream->actual_start_time);
-        $this->assertEquals($this->streamData->actualEndTime, $updatedStream->actual_end_time);
-        $this->assertEquals($this->streamData->status, $updatedStream->status);
-    }
-}
+    // Assert
+    $this->assertEquals($this->stream->id, $updatedStream->id);
+    $this->assertEquals($this->streamData->title, $updatedStream->title);
+    $this->assertEquals($this->streamData->description, $updatedStream->description);
+    $this->assertEquals($this->streamData->thumbnailUrl, $updatedStream->thumbnail_url);
+    $this->assertEquals($this->streamData->plannedStart, $updatedStream->scheduled_start_time);
+    $this->assertEquals($this->streamData->actualStartTime, $updatedStream->actual_start_time);
+    $this->assertEquals($this->streamData->actualEndTime, $updatedStream->actual_end_time);
+    $this->assertEquals($this->streamData->status, $updatedStream->status);
+});

--- a/tests/Feature/Actions/UpdateStreamActionTest.php
+++ b/tests/Feature/Actions/UpdateStreamActionTest.php
@@ -42,12 +42,12 @@ it('updates a stream', function () {
     $updatedStream = (new UpdateStreamAction)->handle($this->stream, $this->streamData);
 
     // Assert
-    $this->assertEquals($this->stream->id, $updatedStream->id);
-    $this->assertEquals($this->streamData->title, $updatedStream->title);
-    $this->assertEquals($this->streamData->description, $updatedStream->description);
-    $this->assertEquals($this->streamData->thumbnailUrl, $updatedStream->thumbnail_url);
-    $this->assertEquals($this->streamData->plannedStart, $updatedStream->scheduled_start_time);
-    $this->assertEquals($this->streamData->actualStartTime, $updatedStream->actual_start_time);
-    $this->assertEquals($this->streamData->actualEndTime, $updatedStream->actual_end_time);
-    $this->assertEquals($this->streamData->status, $updatedStream->status);
+    expect($updatedStream->id)->toEqual($this->stream->id);
+    expect($updatedStream->title)->toEqual($this->streamData->title);
+    expect($updatedStream->description)->toEqual($this->streamData->description);
+    expect($updatedStream->thumbnail_url)->toEqual($this->streamData->thumbnailUrl);
+    expect($updatedStream->scheduled_start_time)->toEqual($this->streamData->plannedStart);
+    expect($updatedStream->actual_start_time)->toEqual($this->streamData->actualStartTime);
+    expect($updatedStream->actual_end_time)->toEqual($this->streamData->actualEndTime);
+    expect($updatedStream->status)->toEqual($this->streamData->status);
 });

--- a/tests/Feature/Commands/CheckIfLiveStreamsHaveEndedCommandTest.php
+++ b/tests/Feature/Commands/CheckIfLiveStreamsHaveEndedCommandTest.php
@@ -5,7 +5,6 @@ use App\Models\Stream;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('updates streams that are currently live', function () {
     // Arrange

--- a/tests/Feature/Commands/CheckIfLiveStreamsHaveEndedCommandTest.php
+++ b/tests/Feature/Commands/CheckIfLiveStreamsHaveEndedCommandTest.php
@@ -1,42 +1,35 @@
 <?php
 
-namespace Tests\Feature\Commands;
-
 use App\Console\Commands\CheckIfLiveStreamsHaveEndedCommand;
 use App\Models\Stream;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
-class CheckIfLiveStreamsHaveEndedCommandTest extends TestCase
-{
-    /** @test */
-    public function it_updates_streams_that_are_currently_live(): void
-    {
-        // Arrange
-        Http::fake();
+uses(TestCase::class);
 
-        // Arrange
-        Stream::factory()->live()->create();
+it('updates streams that are currently live', function () {
+    // Arrange
+    Http::fake();
 
-        // Act & Expect
-        $this->artisan(CheckIfLiveStreamsHaveEndedCommand::class)
-            ->expectsOutput('Fetching 1 stream(s) from API to update their status.')
-            ->assertExitCode(0);
-    }
+    // Arrange
+    Stream::factory()->live()->create();
 
-    /** @test */
-    public function it_does_not_update_finished_or_upcoming_streams(): void
-    {
-        // Arrange
-        Http::fake();
+    // Act & Expect
+    $this->artisan(CheckIfLiveStreamsHaveEndedCommand::class)
+        ->expectsOutput('Fetching 1 stream(s) from API to update their status.')
+        ->assertExitCode(0);
+});
 
-        // Arrange
-        Stream::factory()->upcoming()->create();
-        Stream::factory()->finished()->create();
+it('does not update finished or upcoming streams', function () {
+    // Arrange
+    Http::fake();
 
-        // Act & Expect
-        $this->artisan(CheckIfLiveStreamsHaveEndedCommand::class)
-            ->expectsOutput('There are no streams to update.')
-            ->assertExitCode(0);
-    }
-}
+    // Arrange
+    Stream::factory()->upcoming()->create();
+    Stream::factory()->finished()->create();
+
+    // Act & Expect
+    $this->artisan(CheckIfLiveStreamsHaveEndedCommand::class)
+        ->expectsOutput('There are no streams to update.')
+        ->assertExitCode(0);
+});

--- a/tests/Feature/Commands/CheckIfUpcomingStreamsAreLiveCommandTest.php
+++ b/tests/Feature/Commands/CheckIfUpcomingStreamsAreLiveCommandTest.php
@@ -5,7 +5,6 @@ use App\Models\Stream;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('updates upcoming streams that are soon live', function () {
     // Arrange

--- a/tests/Feature/Commands/CheckIfUpcomingStreamsAreLiveCommandTest.php
+++ b/tests/Feature/Commands/CheckIfUpcomingStreamsAreLiveCommandTest.php
@@ -1,56 +1,47 @@
 <?php
 
-namespace Tests\Feature\Commands;
-
 use App\Console\Commands\CheckIfUpcomingStreamsAreLiveCommand;
 use App\Models\Stream;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
-class CheckIfUpcomingStreamsAreLiveCommandTest extends TestCase
-{
-    /** @test */
-    public function it_updates_upcoming_streams_that_are_soon_live(): void
-    {
-        // Arrange
-        Http::fake();
+uses(TestCase::class);
 
-        // Arrange
-        Stream::factory()->upcoming()->create(['scheduled_start_time' => now()->addMinutes(15)]);
-        Stream::factory()->upcoming()->create(['scheduled_start_time' => now()->addMinutes(20)]);
+it('updates upcoming streams that are soon live', function () {
+    // Arrange
+    Http::fake();
 
-        // Act & Expect
-        $this->artisan(CheckIfUpcomingStreamsAreLiveCommand::class)
-            ->expectsOutput('Fetching 1 stream(s) from API to update their status.')
-            ->assertExitCode(0);
-    }
+    // Arrange
+    Stream::factory()->upcoming()->create(['scheduled_start_time' => now()->addMinutes(15)]);
+    Stream::factory()->upcoming()->create(['scheduled_start_time' => now()->addMinutes(20)]);
 
-    /** @test */
-    public function it_does_not_update_finished_or_live_streams(): void
-    {
-        // Arrange
-        Http::fake();
-        Stream::factory()->live()->create();
-        Stream::factory()->finished()->create();
+    // Act & Expect
+    $this->artisan(CheckIfUpcomingStreamsAreLiveCommand::class)
+        ->expectsOutput('Fetching 1 stream(s) from API to update their status.')
+        ->assertExitCode(0);
+});
 
-        // Act & Expect
-        $this->artisan(CheckIfUpcomingStreamsAreLiveCommand::class)
-            ->expectsOutput('There are no streams to update.')
-            ->assertExitCode(0);
-    }
+it('does not update finished or live streams', function () {
+    // Arrange
+    Http::fake();
+    Stream::factory()->live()->create();
+    Stream::factory()->finished()->create();
 
-    /** @test */
-    public function it_does_not_update_unapproved_streams(): void
-    {
-        // Arrange
-        Http::fake();
+    // Act & Expect
+    $this->artisan(CheckIfUpcomingStreamsAreLiveCommand::class)
+        ->expectsOutput('There are no streams to update.')
+        ->assertExitCode(0);
+});
 
-        // Arrange
-        Stream::factory()->notApproved()->create(['scheduled_start_time' => now()->addMinutes(15)]);
+it('does not update unapproved streams', function () {
+    // Arrange
+    Http::fake();
 
-        // Act & Expect
-        $this->artisan(CheckIfUpcomingStreamsAreLiveCommand::class)
-            ->expectsOutput('There are no streams to update.')
-            ->assertExitCode(0);
-    }
-}
+    // Arrange
+    Stream::factory()->notApproved()->create(['scheduled_start_time' => now()->addMinutes(15)]);
+
+    // Act & Expect
+    $this->artisan(CheckIfUpcomingStreamsAreLiveCommand::class)
+        ->expectsOutput('There are no streams to update.')
+        ->assertExitCode(0);
+});

--- a/tests/Feature/Commands/ImportChannelStreamsCommandTest.php
+++ b/tests/Feature/Commands/ImportChannelStreamsCommandTest.php
@@ -6,7 +6,6 @@ use App\Models\Channel;
 use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('runs import youtube channel streams jobs', function () {
     // Arrange

--- a/tests/Feature/Commands/ImportChannelStreamsCommandTest.php
+++ b/tests/Feature/Commands/ImportChannelStreamsCommandTest.php
@@ -1,29 +1,24 @@
 <?php
 
-namespace Tests\Feature\Commands;
-
 use App\Console\Commands\ImportChannelStreamsCommand;
 use App\Jobs\ImportYoutubeChannelStreamsJob;
 use App\Models\Channel;
 use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
-class ImportChannelStreamsCommandTest extends TestCase
-{
-    /** @test */
-    public function it_runs_import_youtube_channel_streams_jobs(): void
-    {
-        // Arrange
-        Queue::fake();
-        Channel::factory()
-            ->autoImportEnabled()
-            ->count(2)
-            ->create();
+uses(TestCase::class);
 
-        // Act
-        $this->artisan(ImportChannelStreamsCommand::class);
+it('runs import youtube channel streams jobs', function () {
+    // Arrange
+    Queue::fake();
+    Channel::factory()
+        ->autoImportEnabled()
+        ->count(2)
+        ->create();
 
-        // Assert
-        Queue::assertPushed(ImportYoutubeChannelStreamsJob::class, 2);
-    }
-}
+    // Act
+    $this->artisan(ImportChannelStreamsCommand::class);
+
+    // Assert
+    Queue::assertPushed(ImportYoutubeChannelStreamsJob::class, 2);
+});

--- a/tests/Feature/Commands/TweetAboutLiveStreamsCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutLiveStreamsCommandTest.php
@@ -6,7 +6,6 @@ use App\Models\Stream;
 use App\Services\YouTube\StreamData;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('tweets streams that are live', function () {
     // Arrange

--- a/tests/Feature/Commands/TweetAboutLiveStreamsCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutLiveStreamsCommandTest.php
@@ -83,15 +83,15 @@ it('correctly sets tweeted at timestamp', function () {
     $streamDontTweet = Stream::factory()->upcoming()->create();
 
     // Assert
-    $this->assertFalse($streamToTweet->tweetStreamIsLiveWasSend());
-    $this->assertFalse($streamDontTweet->tweetStreamIsLiveWasSend());
+    expect($streamToTweet->tweetStreamIsLiveWasSend())->toBeFalse();
+    expect($streamDontTweet->tweetStreamIsLiveWasSend())->toBeFalse();
 
     // Act
     $this->artisan(TweetAboutLiveStreamsCommand::class);
 
     // Assert
-    $this->assertTrue($streamToTweet->refresh()->tweetStreamIsLiveWasSend());
-    $this->assertFalse($streamDontTweet->refresh()->tweetStreamIsLiveWasSend());
+    expect($streamToTweet->refresh()->tweetStreamIsLiveWasSend())->toBeTrue();
+    expect($streamDontTweet->refresh()->tweetStreamIsLiveWasSend())->toBeFalse();
 });
 
 it('only tweets streams that are going live once', function () {

--- a/tests/Feature/Commands/TweetAboutUpcomingStreamsCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutUpcomingStreamsCommandTest.php
@@ -6,7 +6,6 @@ use App\Models\Stream;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('tweets streams that are upcoming', function () {
     // Arrange

--- a/tests/Feature/Commands/TweetAboutUpcomingStreamsCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutUpcomingStreamsCommandTest.php
@@ -1,181 +1,160 @@
 <?php
 
-namespace Tests\Feature\Commands;
-
 use App\Console\Commands\TweetAboutUpcomingStreamsCommand;
 use App\Models\Channel;
 use App\Models\Stream;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-class TweetAboutUpcomingStreamsCommandTest extends TestCase
-{
-    /** @test */
-    public function it_tweets_streams_that_are_upcoming(): void
-    {
-        // Arrange
-        $stream = Stream::factory()
-            ->upcoming()
-            ->startsWithinUpcomingTweetRange()
-            ->create();
+uses(TestCase::class);
 
-        // Assert
-        $this->twitterFake->assertNoTweetsWereSent();
-        $this->assertFalse($stream->tweetStreamIsUpcomingWasSend());
+it('tweets streams that are upcoming', function () {
+    // Arrange
+    $stream = Stream::factory()
+        ->upcoming()
+        ->startsWithinUpcomingTweetRange()
+        ->create();
 
-        // Act
-        $this->artisan(TweetAboutUpcomingStreamsCommand::class);
+    // Assert
+    $this->twitterFake->assertNoTweetsWereSent();
+    $this->assertFalse($stream->tweetStreamIsUpcomingWasSend());
 
-        // Assert
-        $this->twitterFake->assertTweetWasSent();
-        $this->assertTrue($stream->refresh()->tweetStreamIsUpcomingWasSend());
-    }
+    // Act
+    $this->artisan(TweetAboutUpcomingStreamsCommand::class);
 
-    /** @test */
-    public function it_does_not_tweet_streams_that_are_live_or_finished(): void
-    {
-        // Arrange
-        Stream::factory()->live()->startsWithinUpcomingTweetRange()->create();
-        Stream::factory()->finished()->startsWithinUpcomingTweetRange()->create();
+    // Assert
+    $this->twitterFake->assertTweetWasSent();
+    $this->assertTrue($stream->refresh()->tweetStreamIsUpcomingWasSend());
+});
 
-        // Act
-        $this->artisan(TweetAboutUpcomingStreamsCommand::class);
+it('does not tweet streams that are live or finished', function () {
+    // Arrange
+    Stream::factory()->live()->startsWithinUpcomingTweetRange()->create();
+    Stream::factory()->finished()->startsWithinUpcomingTweetRange()->create();
 
-        // Assert
-        $this->twitterFake->assertNoTweetsWereSent();
-    }
+    // Act
+    $this->artisan(TweetAboutUpcomingStreamsCommand::class);
 
-    /** @test */
-    public function it_checks_the_message_of_the_tweet(): void
-    {
-        // Arrange
-        $stream = Stream::factory()->upcoming()->startsWithinUpcomingTweetRange()->create();
-        $expectedStatus = "🔴 A new stream is about to start: $stream->title. Join now!\n{$stream->url()}";
+    // Assert
+    $this->twitterFake->assertNoTweetsWereSent();
+});
 
-        // Act
-        $this->artisan(TweetAboutUpcomingStreamsCommand::class);
+it('checks the message of the tweet', function () {
+    // Arrange
+    $stream = Stream::factory()->upcoming()->startsWithinUpcomingTweetRange()->create();
+    $expectedStatus = "🔴 A new stream is about to start: $stream->title. Join now!\n{$stream->url()}";
 
-        // Assert
-        $this->twitterFake->assertLastTweetMessageWas($expectedStatus);
-    }
+    // Act
+    $this->artisan(TweetAboutUpcomingStreamsCommand::class);
 
-    /** @test */
-    public function it_adds_twitter_handle_to_streams_connected_to_a_channel(): void
-    {
-        // Arrange
-        $stream = Stream::factory()
-            ->upcoming()
-            ->for(Channel::factory()->create(['twitter_handle' => '@twitterUser']))
-            ->startsWithinUpcomingTweetRange()
-            ->create();
+    // Assert
+    $this->twitterFake->assertLastTweetMessageWas($expectedStatus);
+});
 
-        $expectedStatus = "🔴 A new stream by @twitterUser is about to start: $stream->title. Join now!\n{$stream->url()}";
+it('adds twitter handle to streams connected to a channel', function () {
+    // Arrange
+    $stream = Stream::factory()
+        ->upcoming()
+        ->for(Channel::factory()->create(['twitter_handle' => '@twitterUser']))
+        ->startsWithinUpcomingTweetRange()
+        ->create();
 
-        // Act
-        $this->artisan(TweetAboutUpcomingStreamsCommand::class);
+    $expectedStatus = "🔴 A new stream by @twitterUser is about to start: $stream->title. Join now!\n{$stream->url()}";
 
-        // Assert
-        $this->twitterFake->assertLastTweetMessageWas($expectedStatus);
-    }
+    // Act
+    $this->artisan(TweetAboutUpcomingStreamsCommand::class);
 
-    /** @test */
-    public function it_works_without_missing_twitter_handle_on_connected_channel(): void
-    {
-        // Arrange
-        $stream = Stream::factory()
-            ->upcoming()
-            ->for(Channel::factory()->create(['twitter_handle' => null]))
-            ->startsWithinUpcomingTweetRange()
-            ->create();
+    // Assert
+    $this->twitterFake->assertLastTweetMessageWas($expectedStatus);
+});
 
-        $expectedStatus = "🔴 A new stream is about to start: $stream->title. Join now!\n{$stream->url()}";
+it('works without missing twitter handle on connected channel', function () {
+    // Arrange
+    $stream = Stream::factory()
+        ->upcoming()
+        ->for(Channel::factory()->create(['twitter_handle' => null]))
+        ->startsWithinUpcomingTweetRange()
+        ->create();
 
-        // Act
-        $this->artisan(TweetAboutUpcomingStreamsCommand::class);
+    $expectedStatus = "🔴 A new stream is about to start: $stream->title. Join now!\n{$stream->url()}";
 
-        // Assert
-        $this->twitterFake->assertLastTweetMessageWas($expectedStatus);
-    }
+    // Act
+    $this->artisan(TweetAboutUpcomingStreamsCommand::class);
 
-    /** @test */
-    public function it_correctly_sets_upcoming_tweeted_at_timestamp(): void
-    {
-        // Arrange
-        Carbon::setTestNow(now());
-        $upcomingStreamToTweet = Stream::factory()->upcoming()->startsWithinUpcomingTweetRange()->create();
-        $upcomingStreamNotToTweet = Stream::factory()->upcoming()->startsOutsideUpcomingTweetRange()->create();
-        $liveStreamNotToTweet = Stream::factory()->live()->create();
+    // Assert
+    $this->twitterFake->assertLastTweetMessageWas($expectedStatus);
+});
 
-        // Assert
-        $this->assertNull($upcomingStreamToTweet->upcoming_tweeted_at);
-        $this->assertNull($upcomingStreamNotToTweet->upcoming_tweeted_at);
-        $this->assertNull($liveStreamNotToTweet->upcoming_tweeted_at);
+it('correctly sets upcoming tweeted at timestamp', function () {
+    // Arrange
+    Carbon::setTestNow(now());
+    $upcomingStreamToTweet = Stream::factory()->upcoming()->startsWithinUpcomingTweetRange()->create();
+    $upcomingStreamNotToTweet = Stream::factory()->upcoming()->startsOutsideUpcomingTweetRange()->create();
+    $liveStreamNotToTweet = Stream::factory()->live()->create();
 
-        // Act
-        $this->artisan(TweetAboutUpcomingStreamsCommand::class)
-            ->expectsOutput('1 tweets sent')
-            ->assertExitCode(0);
+    // Assert
+    $this->assertNull($upcomingStreamToTweet->upcoming_tweeted_at);
+    $this->assertNull($upcomingStreamNotToTweet->upcoming_tweeted_at);
+    $this->assertNull($liveStreamNotToTweet->upcoming_tweeted_at);
 
-        // Assert
-        tap($upcomingStreamToTweet->fresh(), function($upcomingStreamToTweet) {
-            $this->assertNotNull($upcomingStreamToTweet->upcoming_tweeted_at);
-            $this->assertInstanceOf(Carbon::class, $upcomingStreamToTweet->upcoming_tweeted_at);
-            $this->assertSame((string) now(), (string) $upcomingStreamToTweet->upcoming_tweeted_at);
-            $this->assertTrue($upcomingStreamToTweet->tweetStreamIsUpcomingWasSend());
-        });
+    // Act
+    $this->artisan(TweetAboutUpcomingStreamsCommand::class)
+        ->expectsOutput('1 tweets sent')
+        ->assertExitCode(0);
 
-        $this->assertNull($upcomingStreamNotToTweet->refresh()->upcoming_tweeted_at);
-        $this->assertNull($liveStreamNotToTweet->refresh()->upcoming_tweeted_at);
-    }
+    // Assert
+    tap($upcomingStreamToTweet->fresh(), function($upcomingStreamToTweet) {
+        $this->assertNotNull($upcomingStreamToTweet->upcoming_tweeted_at);
+        $this->assertInstanceOf(Carbon::class, $upcomingStreamToTweet->upcoming_tweeted_at);
+        $this->assertSame((string) now(), (string) $upcomingStreamToTweet->upcoming_tweeted_at);
+        $this->assertTrue($upcomingStreamToTweet->tweetStreamIsUpcomingWasSend());
+    });
 
-    /** @test */
-    public function it_does_not_send_a_tweet_if_the_live_tweet_is_sent(): void
-    {
-        // Arrange
-        Carbon::setTestNow(now());
+    $this->assertNull($upcomingStreamNotToTweet->refresh()->upcoming_tweeted_at);
+    $this->assertNull($liveStreamNotToTweet->refresh()->upcoming_tweeted_at);
+});
 
-        $stream = Stream::factory()
-            ->upcoming()
-            ->liveTweetWasSend()
-            ->startsWithinUpcomingTweetRange()
-            ->create();
+it('does not send a tweet if the live tweet is sent', function () {
+    // Arrange
+    Carbon::setTestNow(now());
 
-        // Assert
-        $this->assertNull($stream->upcoming_tweeted_at);
+    $stream = Stream::factory()
+        ->upcoming()
+        ->liveTweetWasSend()
+        ->startsWithinUpcomingTweetRange()
+        ->create();
 
-        // Act
-        $this->artisan(TweetAboutUpcomingStreamsCommand::class)
-            ->assertExitCode(0);
+    // Assert
+    $this->assertNull($stream->upcoming_tweeted_at);
 
-        // Assert
-        $this->twitterFake->assertNoTweetsWereSent();
-    }
+    // Act
+    $this->artisan(TweetAboutUpcomingStreamsCommand::class)
+        ->assertExitCode(0);
 
-    /** @test */
-    public function it_only_tweets_streams_that_are_going_live_once(): void
-    {
-        // Arrange
-        Stream::factory()->upcoming()->upcomingTweetWasSend()->create();
+    // Assert
+    $this->twitterFake->assertNoTweetsWereSent();
+});
 
-        // Act
-        $this->artisan(TweetAboutUpcomingStreamsCommand::class);
+it('only tweets streams that are going live once', function () {
+    // Arrange
+    Stream::factory()->upcoming()->upcomingTweetWasSend()->create();
 
-        // Assert
-        $this->twitterFake->assertNoTweetsWereSent();
-    }
+    // Act
+    $this->artisan(TweetAboutUpcomingStreamsCommand::class);
 
-    /** @test */
-    public function it_does_not_tweet_streams_that_are_upcoming_but_already_started(): void
-    {
-        // Arrange
-        Stream::factory()->upcoming()->create([
-            'scheduled_start_time' => now()->subSecond(),
-        ]);
+    // Assert
+    $this->twitterFake->assertNoTweetsWereSent();
+});
 
-        // Act
-        $this->artisan(TweetAboutUpcomingStreamsCommand::class);
+it('does not tweet streams that are upcoming but already started', function () {
+    // Arrange
+    Stream::factory()->upcoming()->create([
+        'scheduled_start_time' => now()->subSecond(),
+    ]);
 
-        // Assert
-        $this->twitterFake->assertNoTweetsWereSent();
-    }
-}
+    // Act
+    $this->artisan(TweetAboutUpcomingStreamsCommand::class);
+
+    // Assert
+    $this->twitterFake->assertNoTweetsWereSent();
+});

--- a/tests/Feature/Commands/TweetAboutUpcomingStreamsCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutUpcomingStreamsCommandTest.php
@@ -17,14 +17,14 @@ it('tweets streams that are upcoming', function () {
 
     // Assert
     $this->twitterFake->assertNoTweetsWereSent();
-    $this->assertFalse($stream->tweetStreamIsUpcomingWasSend());
+    expect($stream->tweetStreamIsUpcomingWasSend())->toBeFalse();
 
     // Act
     $this->artisan(TweetAboutUpcomingStreamsCommand::class);
 
     // Assert
     $this->twitterFake->assertTweetWasSent();
-    $this->assertTrue($stream->refresh()->tweetStreamIsUpcomingWasSend());
+    expect($stream->refresh()->tweetStreamIsUpcomingWasSend())->toBeTrue();
 });
 
 it('does not tweet streams that are live or finished', function () {
@@ -93,9 +93,9 @@ it('correctly sets upcoming tweeted at timestamp', function () {
     $liveStreamNotToTweet = Stream::factory()->live()->create();
 
     // Assert
-    $this->assertNull($upcomingStreamToTweet->upcoming_tweeted_at);
-    $this->assertNull($upcomingStreamNotToTweet->upcoming_tweeted_at);
-    $this->assertNull($liveStreamNotToTweet->upcoming_tweeted_at);
+    expect($upcomingStreamToTweet->upcoming_tweeted_at)->toBeNull();
+    expect($upcomingStreamNotToTweet->upcoming_tweeted_at)->toBeNull();
+    expect($liveStreamNotToTweet->upcoming_tweeted_at)->toBeNull();
 
     // Act
     $this->artisan(TweetAboutUpcomingStreamsCommand::class)
@@ -105,13 +105,13 @@ it('correctly sets upcoming tweeted at timestamp', function () {
     // Assert
     tap($upcomingStreamToTweet->fresh(), function($upcomingStreamToTweet) {
         $this->assertNotNull($upcomingStreamToTweet->upcoming_tweeted_at);
-        $this->assertInstanceOf(Carbon::class, $upcomingStreamToTweet->upcoming_tweeted_at);
-        $this->assertSame((string) now(), (string) $upcomingStreamToTweet->upcoming_tweeted_at);
-        $this->assertTrue($upcomingStreamToTweet->tweetStreamIsUpcomingWasSend());
+        expect($upcomingStreamToTweet->upcoming_tweeted_at)->toBeInstanceOf(Carbon::class);
+        expect((string) $upcomingStreamToTweet->upcoming_tweeted_at)->toBe((string) now());
+        expect($upcomingStreamToTweet->tweetStreamIsUpcomingWasSend())->toBeTrue();
     });
 
-    $this->assertNull($upcomingStreamNotToTweet->refresh()->upcoming_tweeted_at);
-    $this->assertNull($liveStreamNotToTweet->refresh()->upcoming_tweeted_at);
+    expect($upcomingStreamNotToTweet->refresh()->upcoming_tweeted_at)->toBeNull();
+    expect($liveStreamNotToTweet->refresh()->upcoming_tweeted_at)->toBeNull();
 });
 
 it('does not send a tweet if the live tweet is sent', function () {
@@ -125,7 +125,7 @@ it('does not send a tweet if the live tweet is sent', function () {
         ->create();
 
     // Assert
-    $this->assertNull($stream->upcoming_tweeted_at);
+    expect($stream->upcoming_tweeted_at)->toBeNull();
 
     // Act
     $this->artisan(TweetAboutUpcomingStreamsCommand::class)

--- a/tests/Feature/Commands/TweetAboutWeeklySummaryCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutWeeklySummaryCommandTest.php
@@ -5,7 +5,6 @@ use App\Models\Stream;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('tweets weekly summary', function () {
     // Arrange

--- a/tests/Feature/Commands/TweetAboutWeeklySummaryCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutWeeklySummaryCommandTest.php
@@ -1,61 +1,54 @@
 <?php
 
-namespace Tests\Feature\Commands;
-
 use App\Console\Commands\TweetAboutWeeklySummaryCommand;
 use App\Models\Stream;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-class TweetAboutWeeklySummaryCommandTest extends TestCase
-{
-    /** @test */
-    public function it_tweets_weekly_summary(): void
-    {
-        // Arrange
-        $startOfLastWeek = Carbon::today()->subWeek()->startOfWeek();
-        $endOfLastWeek = Carbon::today()->subWeek()->endOfWeek()->endOfDay();
+uses(TestCase::class);
 
-        Stream::factory()
-            ->approved()
-            ->finished()
-            ->create(['actual_start_time' => $startOfLastWeek]);
+it('tweets weekly summary', function () {
+    // Arrange
+    $startOfLastWeek = Carbon::today()->subWeek()->startOfWeek();
+    $endOfLastWeek = Carbon::today()->subWeek()->endOfWeek()->endOfDay();
 
-        Stream::factory()
-            ->approved()
-            ->finished()
-            ->create(['actual_start_time' => $endOfLastWeek]);
+    Stream::factory()
+        ->approved()
+        ->finished()
+        ->create(['actual_start_time' => $startOfLastWeek]);
 
-        // Act
-        $this->artisan(TweetAboutWeeklySummaryCommand::class);
+    Stream::factory()
+        ->approved()
+        ->finished()
+        ->create(['actual_start_time' => $endOfLastWeek]);
 
-        // Assert
-        $this->twitterFake->assertTweetWasSent();
-        $this->twitterFake->assertLastTweetMessageWas("There were 2 streams last week. 👏 Thanks to all the streamers and viewers. 🙏🏻\n Find them here: ".route('archive'));
-    }
+    // Act
+    $this->artisan(TweetAboutWeeklySummaryCommand::class);
 
-    /** @test */
-    public function it_does_not_tweet_weekly_summary_when_no_streams_given(): void
-    {
-        // Arrange
-        $beforeLastWeek = Carbon::today()->subWeek()->startOfWeek()->subDay();
-        $afterLastWeek = Carbon::today();
+    // Assert
+    $this->twitterFake->assertTweetWasSent();
+    $this->twitterFake->assertLastTweetMessageWas("There were 2 streams last week. 👏 Thanks to all the streamers and viewers. 🙏🏻\n Find them here: ".route('archive'));
+});
 
-        Stream::factory()
-            ->approved()
-            ->finished()
-            ->create(['actual_start_time' => $beforeLastWeek]);
+it('does not tweet weekly summary when no streams given', function () {
+    // Arrange
+    $beforeLastWeek = Carbon::today()->subWeek()->startOfWeek()->subDay();
+    $afterLastWeek = Carbon::today();
 
-        Stream::factory()
-            ->approved()
-            ->finished()
-            ->create(['actual_start_time' => $afterLastWeek]);
+    Stream::factory()
+        ->approved()
+        ->finished()
+        ->create(['actual_start_time' => $beforeLastWeek]);
 
-        // Act
-        $this->artisan(TweetAboutWeeklySummaryCommand::class)
-            ->expectsOutput('There were no streams last week.');
+    Stream::factory()
+        ->approved()
+        ->finished()
+        ->create(['actual_start_time' => $afterLastWeek]);
 
-        // Assert
-        $this->twitterFake->assertNoTweetsWereSent();
-    }
-}
+    // Act
+    $this->artisan(TweetAboutWeeklySummaryCommand::class)
+        ->expectsOutput('There were no streams last week.');
+
+    // Assert
+    $this->twitterFake->assertNoTweetsWereSent();
+});

--- a/tests/Feature/Commands/UpdateChannelsCommandTest.php
+++ b/tests/Feature/Commands/UpdateChannelsCommandTest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
-uses(TestCase::class);
 uses(RefreshDatabase::class);
 
 it('updates channels', function () {

--- a/tests/Feature/Commands/UpdateChannelsCommandTest.php
+++ b/tests/Feature/Commands/UpdateChannelsCommandTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Commands;
-
 use App\Console\Commands\UpdateChannelsCommand;
 use App\Facades\YouTube;
 use App\Models\Channel;
@@ -11,73 +9,67 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
-class UpdateChannelsCommandTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function it_updates_channels(): void
-    {
-        // Arrange
-        Http::fake();
-        YouTube::partialMock()
-            ->shouldReceive('channels')
-            ->andReturn(collect([
-                ChannelData::fake(
-                    platformId: '1234',
-                    youTubeCustomUrl: 'test',
-                    name: 'My new test channel',
-                    description: 'My new Description',
-                    thumbnailUrl: 'my-new-thumbnail-url',
-                    onPlatformSince: Carbon::now()->subYear(2),
-                    country: 'US',
-                ),
-                ChannelData::fake(
-                    platformId: '5678',
-                    youTubeCustomUrl: 'test',
-                    name: 'My new test channel #2',
-                    description: 'My new Description #2',
-                    thumbnailUrl: 'my-new-thumbnail-url-2',
-                    onPlatformSince: Carbon::now()->subYear(2),
-                    country: 'DE',
-                ),
-            ]));
+it('updates channels', function () {
+    // Arrange
+    Http::fake();
+    YouTube::partialMock()
+        ->shouldReceive('channels')
+        ->andReturn(collect([
+            ChannelData::fake(
+                platformId: '1234',
+                youTubeCustomUrl: 'test',
+                name: 'My new test channel',
+                description: 'My new Description',
+                thumbnailUrl: 'my-new-thumbnail-url',
+                onPlatformSince: Carbon::now()->subYear(2),
+                country: 'US',
+            ),
+            ChannelData::fake(
+                platformId: '5678',
+                youTubeCustomUrl: 'test',
+                name: 'My new test channel #2',
+                description: 'My new Description #2',
+                thumbnailUrl: 'my-new-thumbnail-url-2',
+                onPlatformSince: Carbon::now()->subYear(2),
+                country: 'DE',
+            ),
+        ]));
 
-        Channel::factory()->create(['platform_id' => '1234']);
-        Channel::factory()->create(['platform_id' => '5678']);
+    Channel::factory()->create(['platform_id' => '1234']);
+    Channel::factory()->create(['platform_id' => '5678']);
 
-        // Act
-        $this->artisan(UpdateChannelsCommand::class)
-            ->expectsOutput('Fetching 2 channels(s) from API to update.')
-            ->assertExitCode(0);
+    // Act
+    $this->artisan(UpdateChannelsCommand::class)
+        ->expectsOutput('Fetching 2 channels(s) from API to update.')
+        ->assertExitCode(0);
 
-        // Assert
-        Http::assertNothingSent();
-        $this->assertDatabaseCount(Channel::class, 2);
-        $this->assertDatabaseHas(Channel::class, [
-            'name' => 'My new test channel',
-            'description' => 'My new Description',
-            'thumbnail_url' => 'my-new-thumbnail-url',
-            'on_platform_since' => Carbon::now()->subYears(2),
-            'country' => 'US',
-        ]);
-        $this->assertDatabaseHas(Channel::class, [
-            'name' => 'My new test channel #2',
-            'description' => 'My new Description #2',
-            'thumbnail_url' => 'my-new-thumbnail-url-2',
-            'country' => 'DE',
-        ]);
-    }
+    // Assert
+    Http::assertNothingSent();
+    $this->assertDatabaseCount(Channel::class, 2);
+    $this->assertDatabaseHas(Channel::class, [
+        'name' => 'My new test channel',
+        'description' => 'My new Description',
+        'thumbnail_url' => 'my-new-thumbnail-url',
+        'on_platform_since' => Carbon::now()->subYears(2),
+        'country' => 'US',
+    ]);
+    $this->assertDatabaseHas(Channel::class, [
+        'name' => 'My new test channel #2',
+        'description' => 'My new Description #2',
+        'thumbnail_url' => 'my-new-thumbnail-url-2',
+        'country' => 'DE',
+    ]);
+});
 
-    /** @test */
-    public function it_does_not_update_channels_if_no_channels_given(): void
-    {
-        // Arrange
-        Http::fake();
+it('does not update channels if no channels given', function () {
+    // Arrange
+    Http::fake();
 
-        // Act & Assert
-        $this->artisan(UpdateChannelsCommand::class)
-            ->expectsOutput('There are no channels to update.')
-            ->assertExitCode(0);
-    }
-}
+    // Act & Assert
+    $this->artisan(UpdateChannelsCommand::class)
+        ->expectsOutput('There are no channels to update.')
+        ->assertExitCode(0);
+});

--- a/tests/Feature/Commands/UpdateLiveAndFinishedStreamsCommandTest.php
+++ b/tests/Feature/Commands/UpdateLiveAndFinishedStreamsCommandTest.php
@@ -7,7 +7,6 @@ use App\Services\YouTube\StreamData;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('updates archived streams', function () {
     Carbon::setTestNow(now());

--- a/tests/Feature/Commands/UpdateLiveAndFinishedStreamsCommandTest.php
+++ b/tests/Feature/Commands/UpdateLiveAndFinishedStreamsCommandTest.php
@@ -39,9 +39,9 @@ it('updates archived streams', function () {
     // Assert
     $existingStream->refresh();
 
-    $this->assertSame(Carbon::yesterday()->addMinutes(3)->toIso8601String(), $existingStream->actual_start_time->toIso8601String());
-    $this->assertSame(Carbon::yesterday()->addMinutes(93)->toIso8601String(), $existingStream->actual_end_time->toIso8601String());
-    $this->assertSame(StreamData::STATUS_FINISHED, $existingStream->status);
+    expect($existingStream->actual_start_time->toIso8601String())->toBe(Carbon::yesterday()->addMinutes(3)->toIso8601String());
+    expect($existingStream->actual_end_time->toIso8601String())->toBe(Carbon::yesterday()->addMinutes(93)->toIso8601String());
+    expect($existingStream->status)->toBe(StreamData::STATUS_FINISHED);
 });
 
 it('marks missing streams as deleted', function () {
@@ -63,9 +63,9 @@ it('marks missing streams as deleted', function () {
     // Assert
     $deletedStream->refresh();
 
-    $this->assertNull($deletedStream->actual_start_time);
-    $this->assertSame(StreamData::STATUS_DELETED, $deletedStream->status);
-    $this->assertSame(Carbon::now()->toIso8601String(), $deletedStream->hidden_at->toIso8601String());
+    expect($deletedStream->actual_start_time)->toBeNull();
+    expect($deletedStream->status)->toBe(StreamData::STATUS_DELETED);
+    expect($deletedStream->hidden_at->toIso8601String())->toBe(Carbon::now()->toIso8601String());
 });
 
 it('updates live streams', function () {
@@ -98,9 +98,9 @@ it('updates live streams', function () {
     // Assert
     $wasLiveStream->refresh();
 
-    $this->assertSame(Carbon::yesterday()->addMinutes(3)->toIso8601String(), $wasLiveStream->actual_start_time->toIso8601String());
-    $this->assertSame(Carbon::yesterday()->addMinutes(93)->toIso8601String(), $wasLiveStream->actual_end_time->toIso8601String());
-    $this->assertSame(StreamData::STATUS_FINISHED, $wasLiveStream->status);
+    expect($wasLiveStream->actual_start_time->toIso8601String())->toBe(Carbon::yesterday()->addMinutes(3)->toIso8601String());
+    expect($wasLiveStream->actual_end_time->toIso8601String())->toBe(Carbon::yesterday()->addMinutes(93)->toIso8601String());
+    expect($wasLiveStream->status)->toBe(StreamData::STATUS_FINISHED);
 });
 
 it('limits the update to the latest 50 streams', function () {
@@ -134,6 +134,6 @@ it('limits the update to the latest 50 streams', function () {
     // Assert
     $stream51->refresh();
 
-    $this->assertNull($stream51->actual_start_time);
-    $this->assertSame(StreamData::STATUS_FINISHED, $stream51->status);
+    expect($stream51->actual_start_time)->toBeNull();
+    expect($stream51->status)->toBe(StreamData::STATUS_FINISHED);
 });

--- a/tests/Feature/Commands/UpdateUpcomingStreamsCommandTest.php
+++ b/tests/Feature/Commands/UpdateUpcomingStreamsCommandTest.php
@@ -7,7 +7,6 @@ use App\Services\YouTube\StreamData;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('updates upcoming streams', function () {
     // Arrange

--- a/tests/Feature/Commands/UpdateUpcomingStreamsCommandTest.php
+++ b/tests/Feature/Commands/UpdateUpcomingStreamsCommandTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Commands;
-
 use App\Console\Commands\UpdateUpcomingStreamsCommand;
 use App\Facades\YouTube;
 use App\Models\Stream;
@@ -9,130 +7,115 @@ use App\Services\YouTube\StreamData;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-class UpdateUpcomingStreamsCommandTest extends TestCase
-{
-    /** @test */
-    public function it_updates_upcoming_streams(): void
-    {
-        // Arrange
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(
-                    videoId: '1234',
-                    title: 'My New Test Stream',
-                    description: 'My New Description',
-                    channelTitle: 'My New Channel Name',
-                    plannedStart: Carbon::tomorrow()
-                ),
-            ]));
+uses(TestCase::class);
 
-        Stream::factory()->upcoming()->create(['youtube_id' => '1234']);
+it('updates upcoming streams', function () {
+    // Arrange
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(
+                videoId: '1234',
+                title: 'My New Test Stream',
+                description: 'My New Description',
+                channelTitle: 'My New Channel Name',
+                plannedStart: Carbon::tomorrow()
+            ),
+        ]));
 
-        // Act
-        $this->artisan(UpdateUpcomingStreamsCommand::class);
+    Stream::factory()->upcoming()->create(['youtube_id' => '1234']);
 
-        // Assert
-        $this->assertDatabaseCount(Stream::class, 1);
-        $this->assertDatabaseHas(Stream::class, [
-            'title' => 'My New Test Stream',
-            'description' => 'My New Description',
-            'thumbnail_url' => 'my-new-thumbnail-url',
-            'scheduled_start_time' => Carbon::tomorrow(),
-        ]);
-    }
+    // Act
+    $this->artisan(UpdateUpcomingStreamsCommand::class);
 
-    /** @test */
-    public function it_does_not_update_finished_or_live_streams(): void
-    {
-        // Arrange
-        Stream::factory()->finished()->create();
-        Stream::factory()->live()->create();
+    // Assert
+    $this->assertDatabaseCount(Stream::class, 1);
+    $this->assertDatabaseHas(Stream::class, [
+        'title' => 'My New Test Stream',
+        'description' => 'My New Description',
+        'thumbnail_url' => 'my-new-thumbnail-url',
+        'scheduled_start_time' => Carbon::tomorrow(),
+    ]);
+});
 
-        // Act & Expect
-        $this->artisan(UpdateUpcomingStreamsCommand::class)
-            ->expectsOutput('There are no streams to update.')
-            ->assertExitCode(0);
-    }
+it('does not update finished or live streams', function () {
+    // Arrange
+    Stream::factory()->finished()->create();
+    Stream::factory()->live()->create();
 
-    /** @test */
-    public function it_does_not_update_unapproved_streams(): void
-    {
-        // Arrange
-        Stream::factory()->notApproved()->create();
+    // Act & Expect
+    $this->artisan(UpdateUpcomingStreamsCommand::class)
+        ->expectsOutput('There are no streams to update.')
+        ->assertExitCode(0);
+});
 
-        // Act & Expect
-        $this->artisan(UpdateUpcomingStreamsCommand::class)
-            ->expectsOutput('There are no streams to update.')
-            ->assertExitCode(0);
-    }
+it('does not update unapproved streams', function () {
+    // Arrange
+    Stream::factory()->notApproved()->create();
 
-    /** @test */
-    public function it_tells_if_there_are_no_streams_to_update(): void
-    {
-        $this->assertDatabaseCount(Stream::class, 0);
+    // Act & Expect
+    $this->artisan(UpdateUpcomingStreamsCommand::class)
+        ->expectsOutput('There are no streams to update.')
+        ->assertExitCode(0);
+});
 
-        // Act & Expect
-        $this->artisan(UpdateUpcomingStreamsCommand::class)
-            ->expectsOutput('There are no streams to update.')
-            ->assertExitCode(0);
-    }
+it('tells if there are no streams to update', function () {
+    $this->assertDatabaseCount(Stream::class, 0);
 
-    /** @test */
-    public function it_tells_how_many_streams_were_updated(): void
-    {
-        // Arrange
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(videoId: '1'),
-                StreamData::fake(videoId: '2'),
-            ]));
+    // Act & Expect
+    $this->artisan(UpdateUpcomingStreamsCommand::class)
+        ->expectsOutput('There are no streams to update.')
+        ->assertExitCode(0);
+});
 
-        Stream::factory()->create(['youtube_id' => '1']);
-        Stream::factory()->create(['youtube_id' => '2']);
+it('tells how many streams were updated', function () {
+    // Arrange
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(videoId: '1'),
+            StreamData::fake(videoId: '2'),
+        ]));
 
-        $this->artisan(UpdateUpcomingStreamsCommand::class)
-            ->expectsOutput('2 stream(s) were updated.')
-            ->assertExitCode(0);
-    }
+    Stream::factory()->create(['youtube_id' => '1']);
+    Stream::factory()->create(['youtube_id' => '2']);
 
-    /** @test */
-    public function it_tells_how_many_streams_were_updated_including_deletes(): void
-    {
-        // Arrange
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(videoId: '1'),
-            ]));
+    $this->artisan(UpdateUpcomingStreamsCommand::class)
+        ->expectsOutput('2 stream(s) were updated.')
+        ->assertExitCode(0);
+});
 
-        Stream::factory()->create(['youtube_id' => '1']);
-        Stream::factory()->create(['youtube_id' => '2']);
+it('tells how many streams were updated including deletes', function () {
+    // Arrange
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(videoId: '1'),
+        ]));
 
-        $this->artisan(UpdateUpcomingStreamsCommand::class)
-            ->expectsOutput('2 stream(s) were updated.')
-            ->assertExitCode(0);
-    }
+    Stream::factory()->create(['youtube_id' => '1']);
+    Stream::factory()->create(['youtube_id' => '2']);
 
-    /** @test */
-    public function it_marks_streams_as_deleted_if_not_given_on_streaming_platform_anymore(): void
-    {
-        // Arrange
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([]));
+    $this->artisan(UpdateUpcomingStreamsCommand::class)
+        ->expectsOutput('2 stream(s) were updated.')
+        ->assertExitCode(0);
+});
 
-        $stream = Stream::factory()->create(['youtube_id' => '1']);
+it('marks streams as deleted if not given on streaming platform anymore', function () {
+    // Arrange
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([]));
 
-        // Act
-        $this->artisan(UpdateUpcomingStreamsCommand::class);
+    $stream = Stream::factory()->create(['youtube_id' => '1']);
 
-        // Assert
-        $this->assertDatabaseCount(Stream::class, 1);
-        $this->assertDatabaseHas(Stream::class, [
-            'title' => $stream->title,
-            'status' => StreamData::STATUS_DELETED,
-        ]);
-    }
-}
+    // Act
+    $this->artisan(UpdateUpcomingStreamsCommand::class);
+
+    // Assert
+    $this->assertDatabaseCount(Stream::class, 1);
+    $this->assertDatabaseHas(Stream::class, [
+        'title' => $stream->title,
+        'status' => StreamData::STATUS_DELETED,
+    ]);
+});

--- a/tests/Feature/FeedTest.php
+++ b/tests/Feature/FeedTest.php
@@ -1,38 +1,33 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Stream;
 use Carbon\Carbon;
 use Tests\TestCase;
 
-class FeedTest extends TestCase
-{
-    /** @test */
-    public function it_provides_streams_in_rss_feed(): void
-    {
-        // Arrange
-        Stream::factory()->create([
-            'title' => 'Stream tomorrow',
-            'description' => 'Stream description',
-            'scheduled_start_time' => Carbon::tomorrow(),
-        ]);
-        Stream::factory()->create(['title' => 'Stream today', 'scheduled_start_time' => Carbon::today()]);
-        Stream::factory()->create(['title' => 'Stream yesterday', 'scheduled_start_time' => Carbon::yesterday()]);
+uses(TestCase::class);
 
-        // Act
-        $response = $this->get('feed');
+it('provides streams in rss feed', function () {
+    // Arrange
+    Stream::factory()->create([
+        'title' => 'Stream tomorrow',
+        'description' => 'Stream description',
+        'scheduled_start_time' => Carbon::tomorrow(),
+    ]);
+    Stream::factory()->create(['title' => 'Stream today', 'scheduled_start_time' => Carbon::today()]);
+    Stream::factory()->create(['title' => 'Stream yesterday', 'scheduled_start_time' => Carbon::yesterday()]);
 
-        // Assert
-        $response->assertSeeInOrder([
-            'Stream tomorrow',
-            'Stream description',
-        ]);
+    // Act
+    $response = $this->get('feed');
 
-        $response->assertSeeInOrder([
-            'Stream tomorrow',
-            'Stream today',
-            'Stream yesterday',
-        ]);
-    }
-}
+    // Assert
+    $response->assertSeeInOrder([
+        'Stream tomorrow',
+        'Stream description',
+    ]);
+
+    $response->assertSeeInOrder([
+        'Stream tomorrow',
+        'Stream today',
+        'Stream yesterday',
+    ]);
+});

--- a/tests/Feature/FeedTest.php
+++ b/tests/Feature/FeedTest.php
@@ -4,7 +4,6 @@ use App\Models\Stream;
 use Carbon\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('provides streams in rss feed', function () {
     // Arrange

--- a/tests/Feature/Http/Controllers/Api/V1/Streams/IndexControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V1/Streams/IndexControllerTest.php
@@ -1,59 +1,52 @@
 <?php
 
-namespace Tests\Feature\Http\Controllers\Api\V1\Streams;
-
 use App\Models\Stream;
 use Tests\TestCase;
 
-class IndexControllerTest extends TestCase
-{
-    /** @test */
-    public function it_shows_all_streams(): void
-    {
-        $stream = Stream::factory()->create([
-            'title' => 'Stream #1',
-            'youtube_id' => '1234',
-        ]);
+uses(TestCase::class);
 
-        $response = $this->json(
-            method: 'GET',
-            uri: '/api/v1/streams',
-        );
+it('shows all streams', function () {
+    $stream = Stream::factory()->create([
+        'title' => 'Stream #1',
+        'youtube_id' => '1234',
+    ]);
 
-        $response->assertStatus(
-            status: 200,
-        )->assertHeader(
-            headerName: 'Content-Type',
-            value: 'application/vnd.api+json',
-        )->assertJsonPath(
-            path: '0.id',
-            expect: $stream->id,
-        )->assertJsonPath(
-            path: '0.attributes.identifiers.youtube',
-            expect: $stream->youtube_id,
-        )->assertJsonPath(
-            path: '0.type',
-            expect: 'stream',
-        )->assertJsonPath(
-            path: '0.attributes.title',
-            expect: $stream->title,
-        );
-    }
+    $response = $this->json(
+        method: 'GET',
+        uri: '/api/v1/streams',
+    );
 
-    /** @test */
-    public function it_only_shows_approved_streams(): void
-    {
-        $stream = Stream::factory()->approved()->create();
-        $stream2 = Stream::factory()->notApproved()->create();
+    $response->assertStatus(
+        status: 200,
+    )->assertHeader(
+        headerName: 'Content-Type',
+        value: 'application/vnd.api+json',
+    )->assertJsonPath(
+        path: '0.id',
+        expect: $stream->id,
+    )->assertJsonPath(
+        path: '0.attributes.identifiers.youtube',
+        expect: $stream->youtube_id,
+    )->assertJsonPath(
+        path: '0.type',
+        expect: 'stream',
+    )->assertJsonPath(
+        path: '0.attributes.title',
+        expect: $stream->title,
+    );
+});
 
-        $response = $this->json(
-            method: 'GET',
-            uri: '/api/v1/streams',
-        );
+it('only shows approved streams', function () {
+    $stream = Stream::factory()->approved()->create();
+    $stream2 = Stream::factory()->notApproved()->create();
 
-        $this->assertCount(
-            expectedCount: 1,
-            haystack: $response->json(),
-        );
-    }
-}
+    $response = $this->json(
+        method: 'GET',
+        uri: '/api/v1/streams',
+    );
+
+    $this->assertCount(
+        expectedCount: 1,
+        haystack: $response->json(),
+    );
+});

--- a/tests/Feature/Http/Controllers/Api/V1/Streams/IndexControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V1/Streams/IndexControllerTest.php
@@ -3,7 +3,6 @@
 use App\Models\Stream;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('shows all streams', function () {
     $stream = Stream::factory()->create([

--- a/tests/Feature/Http/Controllers/CalendarControllerTest.php
+++ b/tests/Feature/Http/Controllers/CalendarControllerTest.php
@@ -1,137 +1,124 @@
 <?php
 
-namespace Tests\Feature\Http\Controllers;
-
 use App\Models\Channel;
 use App\Models\Stream;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-class CalendarControllerTest extends TestCase
-{
-    /** @test **/
-    public function it_shows_all_approved_streams_in_calendar(): void
-    {
-        // Arrange
-        Stream::factory()->approved()->withChannel()->create(['title' => 'Stream two years old', 'scheduled_start_time' => Carbon::now()->subYears(2), 'youtube_id' => '-2y']);
-        Stream::factory()->approved()->withChannel()->create(['title' => 'Stream last year', 'scheduled_start_time' => Carbon::now()->subYear(), 'youtube_id' => '-1y']);
-        Stream::factory()->approved()->withChannel()->create(['title' => 'Stream yesterday', 'scheduled_start_time' => Carbon::yesterday(), 'youtube_id' => '-1d']);
-        Stream::factory()->approved()->withChannel()->create(['title' => 'Stream today', 'scheduled_start_time' => Carbon::now(), 'youtube_id' => 'now']);
-        Stream::factory()->approved()->withChannel()->create(['title' => 'Stream tomorrow', 'scheduled_start_time' => Carbon::tomorrow(), 'youtube_id' => '1d']);
-        Stream::factory()->approved()->withChannel()->create(['title' => 'Stream next week', 'scheduled_start_time' => Carbon::now()->addWeek(), 'youtube_id' => '1w']);
-        Stream::factory()->approved()->withChannel()->create(['title' => 'Stream next month', 'scheduled_start_time' => Carbon::now()->addMonth(), 'youtube_id' => '1m']);
-        Stream::factory()->approved()->withChannel()->create(['title' => 'Stream next year', 'scheduled_start_time' => Carbon::now()->addMonth(), 'youtube_id' => '1y']);
+uses(TestCase::class);
 
-        // Act & Assert
-        $this->get(route('calendar.ics'))
-            ->assertHeader('Content-Type', 'text/calendar; charset=UTF-8')
-            ->assertDontSee([
-                'SUMMARY:Stream two years old',
-                'DESCRIPTION:Stream two years old',
-                'https://www.youtube.com/watch?v=-2y',
-            ])
-            ->assertSeeInOrder([
-                'SUMMARY:Stream last year',
-                'DESCRIPTION:Stream last year',
-                'https://www.youtube.com/watch?v=-1y',
-            ])
-            ->assertSeeInOrder([
-                'SUMMARY:Stream yesterday',
-                'DESCRIPTION:Stream yesterday',
-                'https://www.youtube.com/watch?v=-1d',
-            ])
-            ->assertSeeInOrder([
-                'SUMMARY:Stream today',
-                'DESCRIPTION:Stream today',
-                'https://www.youtube.com/watch?v=now',
-            ])
-            ->assertSeeInOrder([
-                'SUMMARY:Stream tomorrow',
-                'DESCRIPTION:Stream tomorrow',
-                'https://www.youtube.com/watch?v=1d',
-            ])
-            ->assertSeeInOrder([
-                'SUMMARY:Stream next week',
-                'DESCRIPTION:Stream next week',
-                'https://www.youtube.com/watch?v=1w',
-            ])
-            ->assertSeeInOrder([
-                'SUMMARY:Stream next month',
-                'DESCRIPTION:Stream next month',
-                'https://www.youtube.com/watch?v=1m',
-            ])
-            ->assertSeeInOrder([
-                'SUMMARY:Stream next year',
-                'DESCRIPTION:Stream next year',
-                'https://www.youtube.com/watch?v=1y',
-            ]);
+it('shows all approved streams in calendar', function () {
+    // Arrange
+    Stream::factory()->approved()->withChannel()->create(['title' => 'Stream two years old', 'scheduled_start_time' => Carbon::now()->subYears(2), 'youtube_id' => '-2y']);
+    Stream::factory()->approved()->withChannel()->create(['title' => 'Stream last year', 'scheduled_start_time' => Carbon::now()->subYear(), 'youtube_id' => '-1y']);
+    Stream::factory()->approved()->withChannel()->create(['title' => 'Stream yesterday', 'scheduled_start_time' => Carbon::yesterday(), 'youtube_id' => '-1d']);
+    Stream::factory()->approved()->withChannel()->create(['title' => 'Stream today', 'scheduled_start_time' => Carbon::now(), 'youtube_id' => 'now']);
+    Stream::factory()->approved()->withChannel()->create(['title' => 'Stream tomorrow', 'scheduled_start_time' => Carbon::tomorrow(), 'youtube_id' => '1d']);
+    Stream::factory()->approved()->withChannel()->create(['title' => 'Stream next week', 'scheduled_start_time' => Carbon::now()->addWeek(), 'youtube_id' => '1w']);
+    Stream::factory()->approved()->withChannel()->create(['title' => 'Stream next month', 'scheduled_start_time' => Carbon::now()->addMonth(), 'youtube_id' => '1m']);
+    Stream::factory()->approved()->withChannel()->create(['title' => 'Stream next year', 'scheduled_start_time' => Carbon::now()->addMonth(), 'youtube_id' => '1y']);
 
-        // TODOS: We cannot test the description at the end of the DESCRIPTION field
-        // after a specific length, the generated output cuts of the the string
-        // so we cannot assert this string anymore
-        // that's why the description is not in the string.
-        /** @see \Spatie\IcalendarGenerator\Builders\ComponentBuilder::chipLine() */
-    }
+    // Act & Assert
+    $this->get(route('calendar.ics'))
+        ->assertHeader('Content-Type', 'text/calendar; charset=UTF-8')
+        ->assertDontSee([
+            'SUMMARY:Stream two years old',
+            'DESCRIPTION:Stream two years old',
+            'https://www.youtube.com/watch?v=-2y',
+        ])
+        ->assertSeeInOrder([
+            'SUMMARY:Stream last year',
+            'DESCRIPTION:Stream last year',
+            'https://www.youtube.com/watch?v=-1y',
+        ])
+        ->assertSeeInOrder([
+            'SUMMARY:Stream yesterday',
+            'DESCRIPTION:Stream yesterday',
+            'https://www.youtube.com/watch?v=-1d',
+        ])
+        ->assertSeeInOrder([
+            'SUMMARY:Stream today',
+            'DESCRIPTION:Stream today',
+            'https://www.youtube.com/watch?v=now',
+        ])
+        ->assertSeeInOrder([
+            'SUMMARY:Stream tomorrow',
+            'DESCRIPTION:Stream tomorrow',
+            'https://www.youtube.com/watch?v=1d',
+        ])
+        ->assertSeeInOrder([
+            'SUMMARY:Stream next week',
+            'DESCRIPTION:Stream next week',
+            'https://www.youtube.com/watch?v=1w',
+        ])
+        ->assertSeeInOrder([
+            'SUMMARY:Stream next month',
+            'DESCRIPTION:Stream next month',
+            'https://www.youtube.com/watch?v=1m',
+        ])
+        ->assertSeeInOrder([
+            'SUMMARY:Stream next year',
+            'DESCRIPTION:Stream next year',
+            'https://www.youtube.com/watch?v=1y',
+        ]);
 
-    /** @test **/
-    public function it_shows_only_approved_streams_in_calendar(): void
-    {
-        // Arrange
-        Stream::factory()->approved()->withChannel()->create(['title' => 'Stream approved', 'scheduled_start_time' => Carbon::yesterday()]);
-        Stream::factory()->notApproved()->withChannel()->create(['title' => 'Stream not approved', 'scheduled_start_time' => Carbon::yesterday()->subDay()]);
+    // TODOS: We cannot test the description at the end of the DESCRIPTION field
+    // after a specific length, the generated output cuts of the the string
+    // so we cannot assert this string anymore
+    // that's why the description is not in the string.
+    /** @see \Spatie\IcalendarGenerator\Builders\ComponentBuilder::chipLine() */
+});
 
-        // Act & Assert
-        $this->get(route('calendar.ics'))
-            ->assertHeader('Content-Type', 'text/calendar; charset=UTF-8')
-            ->assertDontSee([
-                'SUMMARY:Stream not approved',
-            ])
-            ->assertSeeInOrder([
-                'SUMMARY:Stream approved',
-            ]);
-    }
+it('shows only approved streams in calendar', function () {
+    // Arrange
+    Stream::factory()->approved()->withChannel()->create(['title' => 'Stream approved', 'scheduled_start_time' => Carbon::yesterday()]);
+    Stream::factory()->notApproved()->withChannel()->create(['title' => 'Stream not approved', 'scheduled_start_time' => Carbon::yesterday()->subDay()]);
 
-    /** @test */
-    public function it_can_filter_streams_by_single_language_code()
-    {
-        Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'English Test Stream', 'language_code' => 'en']);
-        Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'Spanish Test Stream', 'language_code' => 'es']);
+    // Act & Assert
+    $this->get(route('calendar.ics'))
+        ->assertHeader('Content-Type', 'text/calendar; charset=UTF-8')
+        ->assertDontSee([
+            'SUMMARY:Stream not approved',
+        ])
+        ->assertSeeInOrder([
+            'SUMMARY:Stream approved',
+        ]);
+});
 
-        $this->get(route('calendar.ics', ['languages' => 'en']))
-            ->assertSee('English Test Stream')
-            ->assertDontSee('Spanish Test Stream');
-    }
+it('can filter streams by single language code', function () {
+    Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'English Test Stream', 'language_code' => 'en']);
+    Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'Spanish Test Stream', 'language_code' => 'es']);
 
-    /** @test */
-    public function it_can_filter_streams_by_multiple_language_codes()
-    {
-        Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'English Test Stream', 'language_code' => 'en']);
-        Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'Spanish Test Stream', 'language_code' => 'es']);
-        Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'French Test Stream', 'language_code' => 'fr']);
+    $this->get(route('calendar.ics', ['languages' => 'en']))
+        ->assertSee('English Test Stream')
+        ->assertDontSee('Spanish Test Stream');
+});
 
-        $this->get(route('calendar.ics', ['languages' => 'en,es']))
-            ->assertSee('English Test Stream')
-            ->assertSee('Spanish Test Stream')
-            ->assertDontSee('French Test Stream');
-    }
+it('can filter streams by multiple language codes', function () {
+    Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'English Test Stream', 'language_code' => 'en']);
+    Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'Spanish Test Stream', 'language_code' => 'es']);
+    Stream::factory()->for(Channel::factory()->create(['name' => 'Laravel']))->create(['title' => 'French Test Stream', 'language_code' => 'fr']);
 
-    /** @test */
-    public function it_can_download_one_calendar_item(): void
-    {
-        $stream = Stream::factory()
-            ->for(Channel::factory()->create(['name' => 'My Channel']))
-            ->create([
-                'title' => 'Single Stream',
-                'scheduled_start_time' => Carbon::now(),
-                'youtube_id' => '1234',
-            ]);
+    $this->get(route('calendar.ics', ['languages' => 'en,es']))
+        ->assertSee('English Test Stream')
+        ->assertSee('Spanish Test Stream')
+        ->assertDontSee('French Test Stream');
+});
 
-        $this
-            ->get(route('calendar.ics.stream', $stream))
-            ->assertHeader('Content-Type', 'text/calendar; charset=UTF-8')
-            ->assertSeeInOrder([
-                'SUMMARY:Single Stream',
-                'DESCRIPTION:Single Stream\nMy Channel\nhttps://www.youtube.com/watch?v=1234',
-            ]);
-    }
-}
+it('can download one calendar item', function () {
+    $stream = Stream::factory()
+        ->for(Channel::factory()->create(['name' => 'My Channel']))
+        ->create([
+            'title' => 'Single Stream',
+            'scheduled_start_time' => Carbon::now(),
+            'youtube_id' => '1234',
+        ]);
+
+    $this
+        ->get(route('calendar.ics.stream', $stream))
+        ->assertHeader('Content-Type', 'text/calendar; charset=UTF-8')
+        ->assertSeeInOrder([
+            'SUMMARY:Single Stream',
+            'DESCRIPTION:Single Stream\nMy Channel\nhttps://www.youtube.com/watch?v=1234',
+        ]);
+});

--- a/tests/Feature/Http/Controllers/CalendarControllerTest.php
+++ b/tests/Feature/Http/Controllers/CalendarControllerTest.php
@@ -5,7 +5,6 @@ use App\Models\Stream;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('shows all approved streams in calendar', function () {
     // Arrange

--- a/tests/Feature/Http/Controllers/Submission/ApproveStreamControllerTest.php
+++ b/tests/Feature/Http/Controllers/Submission/ApproveStreamControllerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Http\Controllers\Submission;
-
 use App\Mail\StreamApprovedMail;
 use App\Models\Stream;
 use Illuminate\Support\Facades\Artisan;
@@ -10,34 +8,30 @@ use Illuminate\Support\Facades\Mail;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-class ApproveStreamControllerTest extends TestCase
-{
-    use YouTubeResponses;
+uses(TestCase::class);
+uses(YouTubeResponses::class);
 
-    /** @test */
-    public function it_can_approve_a_stream_using_a_signed_url(): void
-    {
-        // Arrange
-        Http::fake(fn() => Http::response($this->videoResponse()));
-        Mail::fake();
-        $stream = Stream::factory()
-            ->notApproved()
-            ->create([
-                'submitted_by_email' => 'john@example.com',
-            ]);
+it('can approve a stream using a signed url', function () {
+    // Arrange
+    Http::fake(fn() => Http::response($this->videoResponse()));
+    Mail::fake();
+    $stream = Stream::factory()
+        ->notApproved()
+        ->create([
+            'submitted_by_email' => 'john@example.com',
+        ]);
 
-        Artisan::spy();
+    Artisan::spy();
 
-        // Assert
-        $this->assertFalse($stream->isApproved());
+    // Assert
+    $this->assertFalse($stream->isApproved());
 
-        // Act
-        $this->get($stream->approveUrl())
-            ->assertOk();
+    // Act
+    $this->get($stream->approveUrl())
+        ->assertOk();
 
-        // Assert
-        $this->assertTrue($stream->refresh()->isApproved());
+    // Assert
+    $this->assertTrue($stream->refresh()->isApproved());
 
-        Mail::assertQueued(StreamApprovedMail::class);
-    }
-}
+    Mail::assertQueued(StreamApprovedMail::class);
+});

--- a/tests/Feature/Http/Controllers/Submission/ApproveStreamControllerTest.php
+++ b/tests/Feature/Http/Controllers/Submission/ApproveStreamControllerTest.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Mail;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-uses(TestCase::class);
 uses(YouTubeResponses::class);
 
 it('can approve a stream using a signed url', function () {

--- a/tests/Feature/Http/Controllers/Submission/ApproveStreamControllerTest.php
+++ b/tests/Feature/Http/Controllers/Submission/ApproveStreamControllerTest.php
@@ -24,14 +24,14 @@ it('can approve a stream using a signed url', function () {
     Artisan::spy();
 
     // Assert
-    $this->assertFalse($stream->isApproved());
+    expect($stream->isApproved())->toBeFalse();
 
     // Act
     $this->get($stream->approveUrl())
         ->assertOk();
 
     // Assert
-    $this->assertTrue($stream->refresh()->isApproved());
+    expect($stream->refresh()->isApproved())->toBeTrue();
 
     Mail::assertQueued(StreamApprovedMail::class);
 });

--- a/tests/Feature/Http/Controllers/Submission/RejectStreamControllerTest.php
+++ b/tests/Feature/Http/Controllers/Submission/RejectStreamControllerTest.php
@@ -4,7 +4,6 @@ use App\Models\Stream;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can reject a stream using a signed url', function () {
     // Arrange

--- a/tests/Feature/Http/Controllers/Submission/RejectStreamControllerTest.php
+++ b/tests/Feature/Http/Controllers/Submission/RejectStreamControllerTest.php
@@ -1,33 +1,28 @@
 <?php
 
-namespace Tests\Feature\Http\Controllers\Submission;
-
 use App\Models\Stream;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
-class RejectStreamControllerTest extends TestCase
-{
-    /** @test */
-    public function it_can_reject_a_stream_using_a_signed_url()
-    {
-        // Arrange
-        Mail::fake();
+uses(TestCase::class);
 
-        $stream = Stream::factory()
-            ->notApproved()
-            ->create([
-                'submitted_by_email' => 'john@example.com',
-            ]);
+it('can reject a stream using a signed url', function () {
+    // Arrange
+    Mail::fake();
 
-        // Assert
-        $this->assertFalse($stream->isApproved());
+    $stream = Stream::factory()
+        ->notApproved()
+        ->create([
+            'submitted_by_email' => 'john@example.com',
+        ]);
 
-        // Act
-        $this->get($stream->rejectUrl())
-            ->assertOk();
+    // Assert
+    $this->assertFalse($stream->isApproved());
 
-        // Assert
-        $this->assertFalse($stream->refresh()->isApproved());
-    }
-}
+    // Act
+    $this->get($stream->rejectUrl())
+        ->assertOk();
+
+    // Assert
+    $this->assertFalse($stream->refresh()->isApproved());
+});

--- a/tests/Feature/Http/Controllers/Submission/RejectStreamControllerTest.php
+++ b/tests/Feature/Http/Controllers/Submission/RejectStreamControllerTest.php
@@ -17,12 +17,12 @@ it('can reject a stream using a signed url', function () {
         ]);
 
     // Assert
-    $this->assertFalse($stream->isApproved());
+    expect($stream->isApproved())->toBeFalse();
 
     // Act
     $this->get($stream->rejectUrl())
         ->assertOk();
 
     // Assert
-    $this->assertFalse($stream->refresh()->isApproved());
+    expect($stream->refresh()->isApproved())->toBeFalse();
 });

--- a/tests/Feature/Http/Controllers/Submission/SubmissionModalTest.php
+++ b/tests/Feature/Http/Controllers/Submission/SubmissionModalTest.php
@@ -3,7 +3,6 @@
 use App\Http\Livewire\SubmitYouTubeLiveStream;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('includes the submission livewire component on all pages', function () {
     $this->get(route('home'))

--- a/tests/Feature/Http/Controllers/Submission/SubmissionModalTest.php
+++ b/tests/Feature/Http/Controllers/Submission/SubmissionModalTest.php
@@ -1,19 +1,14 @@
 <?php
 
-namespace Tests\Feature\Http\Controllers\Submission;
-
 use App\Http\Livewire\SubmitYouTubeLiveStream;
 use Tests\TestCase;
 
-class SubmissionModalTest extends TestCase
-{
-    /** @test */
-    public function it_includes_the_submission_livewire_component_on_all_pages(): void
-    {
-        $this->get(route('home'))
-            ->assertSeeLivewire(SubmitYouTubeLiveStream::class);
+uses(TestCase::class);
 
-        $this->get(route('archive'))
-            ->assertSeeLivewire(SubmitYouTubeLiveStream::class);
-    }
-}
+it('includes the submission livewire component on all pages', function () {
+    $this->get(route('home'))
+        ->assertSeeLivewire(SubmitYouTubeLiveStream::class);
+
+    $this->get(route('archive'))
+        ->assertSeeLivewire(SubmitYouTubeLiveStream::class);
+});

--- a/tests/Feature/Http/Livewire/ImportYoutubeChannelTest.php
+++ b/tests/Feature/Http/Livewire/ImportYoutubeChannelTest.php
@@ -9,7 +9,6 @@ use Livewire\Livewire;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-uses(TestCase::class);
 uses(YouTubeResponses::class);
 
 it('adds channel to database', function () {

--- a/tests/Feature/Http/Livewire/ImportYoutubeChannelTest.php
+++ b/tests/Feature/Http/Livewire/ImportYoutubeChannelTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Http\Livewire;
-
 use App\Http\Livewire\ImportYouTubeChannel;
 use App\Jobs\ImportYoutubeChannelStreamsJob;
 use App\Models\Channel;
@@ -11,97 +9,83 @@ use Livewire\Livewire;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-class ImportYoutubeChannelTest extends TestCase
-{
-    use YouTubeResponses;
+uses(TestCase::class);
+uses(YouTubeResponses::class);
 
-    /** @test */
-    public function it_adds_channel_to_database(): void
-    {
-        // Arrange
-        Queue::fake();
+it('adds channel to database', function () {
+    // Arrange
+    Queue::fake();
 
-        // Assert
-        $this->assertDatabaseCount(Channel::class, 0);
+    // Assert
+    $this->assertDatabaseCount(Channel::class, 0);
 
-        // Arrange & Act
-        Http::fake(fn() => Http::response($this->channelResponse()));
+    // Arrange & Act
+    Http::fake(fn() => Http::response($this->channelResponse()));
 
-        Livewire::test(ImportYouTubeChannel::class)
-            ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
-            ->call('importChannel');
+    Livewire::test(ImportYouTubeChannel::class)
+        ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
+        ->call('importChannel');
 
-        // Assert
-        $this->assertDatabaseCount(Channel::class, 1);
-        $this->assertDatabaseHas(Channel::class, [
-            'platform' => 'youtube',
-            'platform_id' => 'UCdtd5QYBx9MUVXHm7qgEpxA',
-        ]);
-    }
+    // Assert
+    $this->assertDatabaseCount(Channel::class, 1);
+    $this->assertDatabaseHas(Channel::class, [
+        'platform' => 'youtube',
+        'platform_id' => 'UCdtd5QYBx9MUVXHm7qgEpxA',
+    ]);
+});
 
-    /** @test */
-    public function it_dispatches_job_to_import_upcoming_streams(): void
-    {
-        // Arrange
-        Queue::fake();
-        Http::fake(fn() => Http::response($this->channelResponse()));
+it('dispatches job to import upcoming streams', function () {
+    // Arrange
+    Queue::fake();
+    Http::fake(fn() => Http::response($this->channelResponse()));
 
-        // Act
-        Livewire::test(ImportYouTubeChannel::class)
-            ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
-            ->call('importChannel');
+    // Act
+    Livewire::test(ImportYouTubeChannel::class)
+        ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
+        ->call('importChannel');
 
-        // Assert
-        Queue::assertPushed(ImportYoutubeChannelStreamsJob::class);
-    }
+    // Assert
+    Queue::assertPushed(ImportYoutubeChannelStreamsJob::class);
+});
 
-    /** @test */
-    public function it_shows_success_message(): void
-    {
-        // Arrange
-        Queue::fake();
-        Http::fake(fn() => Http::response($this->channelResponse()));
+it('shows success message', function () {
+    // Arrange
+    Queue::fake();
+    Http::fake(fn() => Http::response($this->channelResponse()));
 
-        // Act & Assert
-        Livewire::test(ImportYouTubeChannel::class)
-            ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
-            ->call('importChannel')
-            ->assertSee('Channel "UCdtd5QYBx9MUVXHm7qgEpxA" was added successfully.');
-    }
+    // Act & Assert
+    Livewire::test(ImportYouTubeChannel::class)
+        ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
+        ->call('importChannel')
+        ->assertSee('Channel "UCdtd5QYBx9MUVXHm7qgEpxA" was added successfully.');
+});
 
-    /** @test */
-    public function it_shows_youtube_client_error_message(): void
-    {
-        // Arrange
-        Http::fake(fn() => Http::response([], 500));
+it('shows youtube client error message', function () {
+    // Arrange
+    Http::fake(fn() => Http::response([], 500));
 
-        // Arrange & Act & Assert
-        Livewire::test(ImportYouTubeChannel::class)
-            ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
-            ->call('importChannel')
-            ->assertSee('YouTube API error: 500');
-    }
+    // Arrange & Act & Assert
+    Livewire::test(ImportYouTubeChannel::class)
+        ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
+        ->call('importChannel')
+        ->assertSee('YouTube API error: 500');
+});
 
-    /** @test */
-    public function it_clears_form_after_successful_import(): void
-    {
-        // Arrange
-        Queue::fake();
-        Http::fake(fn() => Http::response($this->channelResponse()));
+it('clears form after successful import', function () {
+    // Arrange
+    Queue::fake();
+    Http::fake(fn() => Http::response($this->channelResponse()));
 
-        // Act & Assert
-        Livewire::test(ImportYouTubeChannel::class)
-            ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
-            ->call('importChannel')
-            ->assertSet('youTubeChannelId', '');
-    }
+    // Act & Assert
+    Livewire::test(ImportYouTubeChannel::class)
+        ->set('youTubeChannelId', 'UCdtd5QYBx9MUVXHm7qgEpxA')
+        ->call('importChannel')
+        ->assertSet('youTubeChannelId', '');
+});
 
-    /** @test */
-    public function it_wires_properties_and_methods(): void
-    {
-        // Arrange & Act & Assert
-        Livewire::test(ImportYouTubeChannel::class)
-            ->assertPropertyWired('youTubeChannelId')
-            ->assertMethodWiredToForm('importChannel');
-    }
-}
+it('wires properties and methods', function () {
+    // Arrange & Act & Assert
+    Livewire::test(ImportYouTubeChannel::class)
+        ->assertPropertyWired('youTubeChannelId')
+        ->assertMethodWiredToForm('importChannel');
+});

--- a/tests/Feature/Http/Livewire/ImportYoutubeLiveStreamTest.php
+++ b/tests/Feature/Http/Livewire/ImportYoutubeLiveStreamTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Http\Livewire;
-
 use App\Facades\YouTube;
 use App\Http\Livewire\ImportYouTubeLiveStream;
 use App\Models\Stream;
@@ -11,149 +9,134 @@ use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class ImportYoutubeLiveStreamTest extends TestCase
-{
-    /** @test */
-    public function it_imports_upcoming_stream_from_youTube_url(): void
-    {
-        // Arrange
-        $scheduledStartTime = Carbon::tomorrow();
+uses(TestCase::class);
 
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(
-                    videoId: 'bcnR4NYOw2o',
-                    title: 'My Test Stream',
-                    description: 'Test Description',
-                    channelTitle: 'My Test Channel',
-                    thumbnailUrl: 'my-test-thumbnail-url',
-                    plannedStart: $scheduledStartTime,
-                ),
-            ]));
+it('imports upcoming stream from you tube url', function () {
+    // Arrange
+    $scheduledStartTime = Carbon::tomorrow();
 
-        $this->assertDatabaseCount(Stream::class, 0);
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(
+                videoId: 'bcnR4NYOw2o',
+                title: 'My Test Stream',
+                description: 'Test Description',
+                channelTitle: 'My Test Channel',
+                thumbnailUrl: 'my-test-thumbnail-url',
+                plannedStart: $scheduledStartTime,
+            ),
+        ]));
 
-        // Act
-        Livewire::test(ImportYouTubeLiveStream::class)
-            ->set('youTubeId', 'bcnR4NYOw2o')
-            ->call('importStream');
+    $this->assertDatabaseCount(Stream::class, 0);
 
-        // Assert
-        $this->assertDatabaseHas(Stream::class, [
-            'youtube_id' => 'bcnR4NYOw2o',
-            'title' => 'My Test Stream',
-            'description' => 'Test Description',
-            'thumbnail_url' => 'my-test-thumbnail-url',
-            'scheduled_start_time' => $scheduledStartTime,
-        ]);
-    }
+    // Act
+    Livewire::test(ImportYouTubeLiveStream::class)
+        ->set('youTubeId', 'bcnR4NYOw2o')
+        ->call('importStream');
 
-    /** @test */
-    public function it_does_not_import_streams_which_are_not_upcoming(): void
-    {
-        // Arrange
-        Http::fake();
+    // Assert
+    $this->assertDatabaseHas(Stream::class, [
+        'youtube_id' => 'bcnR4NYOw2o',
+        'title' => 'My Test Stream',
+        'description' => 'Test Description',
+        'thumbnail_url' => 'my-test-thumbnail-url',
+        'scheduled_start_time' => $scheduledStartTime,
+    ]);
+});
 
-        // it passes because the video was not found because
-        $this->assertDatabaseCount(Stream::class, 0);
+it('does not import streams which are not upcoming', function () {
+    // Arrange
+    Http::fake();
 
-        // Arrange & Act & Assert
-        Livewire::test(ImportYouTubeLiveStream::class)
-            ->set('youTubeId', 'bcnR4NYOw2o')
-            ->call('importStream')
-            ->assertHasErrors(['stream']);
+    // it passes because the video was not found because
+    $this->assertDatabaseCount(Stream::class, 0);
 
-        $this->assertDatabaseCount(Stream::class, 0);
-    }
+    // Arrange & Act & Assert
+    Livewire::test(ImportYouTubeLiveStream::class)
+        ->set('youTubeId', 'bcnR4NYOw2o')
+        ->call('importStream')
+        ->assertHasErrors(['stream']);
 
-    /** @test */
-    public function it_overrides_if_a_stream_is_already_given(): void
-    {
-        // Arrange
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(
-                    videoId: '1234',
-                    title: 'My New Test Stream',
-                ),
-            ]));
+    $this->assertDatabaseCount(Stream::class, 0);
+});
 
-        Stream::factory()->create(['youtube_id' => '1234', 'title' => 'Old title']);
+it('overrides if a stream is already given', function () {
+    // Arrange
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(
+                videoId: '1234',
+                title: 'My New Test Stream',
+            ),
+        ]));
 
-        // Assert
-        $this->assertDatabaseCount(Stream::class, 1);
+    Stream::factory()->create(['youtube_id' => '1234', 'title' => 'Old title']);
 
-        // Arrange & Act & Assert
-        Livewire::test(ImportYouTubeLiveStream::class)
-            ->set('youTubeId', '1234')
-            ->call('importStream');
+    // Assert
+    $this->assertDatabaseCount(Stream::class, 1);
 
-        $this->assertDatabaseCount(Stream::class, 1);
-        $this->assertDatabaseHas(Stream::class, [
-            'youtube_id' => '1234',
-            'title' => 'My New Test Stream',
-        ]);
-    }
+    // Arrange & Act & Assert
+    Livewire::test(ImportYouTubeLiveStream::class)
+        ->set('youTubeId', '1234')
+        ->call('importStream');
 
-    /** @test */
-    public function it_shows_success_message(): void
-    {
-        // Arrange
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(
-                    videoId: '1234',
-                ),
-            ]));
+    $this->assertDatabaseCount(Stream::class, 1);
+    $this->assertDatabaseHas(Stream::class, [
+        'youtube_id' => '1234',
+        'title' => 'My New Test Stream',
+    ]);
+});
 
-        // Act & Assert
-        Livewire::test(ImportYouTubeLiveStream::class)
-            ->set('youTubeId', '1234')
-            ->call('importStream')
-            ->assertSee('Stream "1234" was added successfully.');
-    }
+it('shows success message', function () {
+    // Arrange
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(
+                videoId: '1234',
+            ),
+        ]));
 
-    /** @test */
-    public function it_clears_form_after_successful_import(): void
-    {
-        // Arrange
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(
-                    videoId: '1234',
-                ),
-            ]));
+    // Act & Assert
+    Livewire::test(ImportYouTubeLiveStream::class)
+        ->set('youTubeId', '1234')
+        ->call('importStream')
+        ->assertSee('Stream "1234" was added successfully.');
+});
 
-        // Act & Assert
-        Livewire::test(ImportYouTubeLiveStream::class)
-            ->set('youTubeId', '1234')
-            ->call('importStream')
-            ->assertSet('youTubeId', '');
-    }
+it('clears form after successful import', function () {
+    // Arrange
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(
+                videoId: '1234',
+            ),
+        ]));
 
-    /** @test */
-    public function it_shows_youTube_client_error_message(): void
-    {
-        // Arrange
-        Http::fake(fn() => Http::response([], 500));
+    // Act & Assert
+    Livewire::test(ImportYouTubeLiveStream::class)
+        ->set('youTubeId', '1234')
+        ->call('importStream')
+        ->assertSet('youTubeId', '');
+});
 
-        // Arrange & Act & Assert
-        Livewire::test(ImportYouTubeLiveStream::class)
-            ->set('youTubeId', '1234')
-            ->call('importStream')
-            ->assertSee('YouTube API error: 500');
-    }
+it('shows you tube client error message', function () {
+    // Arrange
+    Http::fake(fn() => Http::response([], 500));
 
-    /** @test */
-    public function it_checks_properties_and_method_wired_to_the_view(): void
-    {
-        // Arrange & Act & Assert
-        Livewire::test(ImportYouTubeLiveStream::class)
-            ->assertPropertyWired('youTubeId')
-            ->assertMethodWiredToForm('importStream');
-    }
-}
+    // Arrange & Act & Assert
+    Livewire::test(ImportYouTubeLiveStream::class)
+        ->set('youTubeId', '1234')
+        ->call('importStream')
+        ->assertSee('YouTube API error: 500');
+});
+
+it('checks properties and method wired to the view', function () {
+    // Arrange & Act & Assert
+    Livewire::test(ImportYouTubeLiveStream::class)
+        ->assertPropertyWired('youTubeId')
+        ->assertMethodWiredToForm('importStream');
+});

--- a/tests/Feature/Http/Livewire/ImportYoutubeLiveStreamTest.php
+++ b/tests/Feature/Http/Livewire/ImportYoutubeLiveStreamTest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('imports upcoming stream from you tube url', function () {
     // Arrange

--- a/tests/Feature/Http/Livewire/StreamListArchiveTest.php
+++ b/tests/Feature/Http/Livewire/StreamListArchiveTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Http\Livewire;
-
 use App\Http\Livewire\StreamListArchive;
 use App\Models\Channel;
 use App\Models\Stream;
@@ -9,50 +7,43 @@ use Livewire\Livewire;
 use Tests\TestCase;
 use Vinkla\Hashids\Facades\Hashids;
 
-class StreamListArchiveTest extends TestCase
-{
-    /** @test */
-    public function it_only_shows_streams_by_selected_streamer(): void
-    {
-        // Arrange
-        Stream::factory()
-            ->for(Channel::factory()->create(['name' => 'My Channel']))
-            ->finished()
-            ->create(['title' => 'Stream Seen', 'channel_id' => 1]);
-        Stream::factory()
-            ->for(Channel::factory()->create(['name' => 'My Channel']))
-            ->finished()
-            ->create(['title' => 'Stream Not Seen', 'channel_id' => 2]);
+uses(TestCase::class);
 
-        // Act & Assert
-        Livewire::test(StreamListArchive::class)
-            ->set('streamer', Hashids::encode(1))
-            ->assertSee('Stream Seen')
-            ->assertDontSee('Stream Not Seen');
-    }
+it('only shows streams by selected streamer', function () {
+    // Arrange
+    Stream::factory()
+        ->for(Channel::factory()->create(['name' => 'My Channel']))
+        ->finished()
+        ->create(['title' => 'Stream Seen', 'channel_id' => 1]);
+    Stream::factory()
+        ->for(Channel::factory()->create(['name' => 'My Channel']))
+        ->finished()
+        ->create(['title' => 'Stream Not Seen', 'channel_id' => 2]);
 
-    /** @test */
-    public function it_shows_streamers_as_dropdown_options(): void
-    {
-        // Arrange
-        Channel::factory()
-            ->create(['name' => 'Channel A']);
-        Channel::factory()
-            ->create(['name' => 'Channel B']);
+    // Act & Assert
+    Livewire::test(StreamListArchive::class)
+        ->set('streamer', Hashids::encode(1))
+        ->assertSee('Stream Seen')
+        ->assertDontSee('Stream Not Seen');
+});
 
-        // Arrange & Act & Assert
-        Livewire::test(StreamListArchive::class)
-            ->assertSee([
-                'Channel A',
-                'Channel B',
-            ]);
-    }
+it('shows streamers as dropdown options', function () {
+    // Arrange
+    Channel::factory()
+        ->create(['name' => 'Channel A']);
+    Channel::factory()
+        ->create(['name' => 'Channel B']);
 
-    /** @test */
-    public function it_wires_properties_and_methods(): void
-    {
-        // Arrange & Act & Assert
-        Livewire::test(StreamListArchive::class)
-            ->assertPropertyWired('streamer');
-    }
-}
+    // Arrange & Act & Assert
+    Livewire::test(StreamListArchive::class)
+        ->assertSee([
+            'Channel A',
+            'Channel B',
+        ]);
+});
+
+it('wires properties and methods', function () {
+    // Arrange & Act & Assert
+    Livewire::test(StreamListArchive::class)
+        ->assertPropertyWired('streamer');
+});

--- a/tests/Feature/Http/Livewire/StreamListArchiveTest.php
+++ b/tests/Feature/Http/Livewire/StreamListArchiveTest.php
@@ -7,7 +7,6 @@ use Livewire\Livewire;
 use Tests\TestCase;
 use Vinkla\Hashids\Facades\Hashids;
 
-uses(TestCase::class);
 
 it('only shows streams by selected streamer', function () {
     // Arrange

--- a/tests/Feature/Http/Livewire/SubmitYouTubeLiveStreamTest.php
+++ b/tests/Feature/Http/Livewire/SubmitYouTubeLiveStreamTest.php
@@ -8,7 +8,6 @@ use App\Services\YouTube\StreamData;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('calls the submit action', function () {
     // Arrange

--- a/tests/Feature/Http/Livewire/SubmitYouTubeLiveStreamTest.php
+++ b/tests/Feature/Http/Livewire/SubmitYouTubeLiveStreamTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Http\Livewire;
-
 use App\Actions\Submission\SubmitStreamAction;
 use App\Facades\YouTube;
 use App\Http\Livewire\SubmitYouTubeLiveStream;
@@ -10,196 +8,174 @@ use App\Services\YouTube\StreamData;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class SubmitYouTubeLiveStreamTest extends TestCase
+uses(TestCase::class);
+
+it('calls the submit action', function () {
+    // Arrange
+    $this->mock(SubmitStreamAction::class)
+        ->shouldReceive('handle')
+        ->withArgs(['1234', 'de', 'test@test.at'])
+        ->once();
+
+    mockYouTubVideoCall();
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('youTubeIdOrUrl', '1234')
+        ->set('submittedByEmail', 'test@test.at')
+        ->set('languageCode', 'de')
+        ->call('submit');
+});
+
+it('calls the submit action with full youtube url', function () {
+    // Arrange
+    $fullYoutubeUrl = 'https://www.youtube.com/watch?v=bcnR4NYOw2o';
+    $this->mock(SubmitStreamAction::class)
+        ->shouldReceive('handle')
+        ->withArgs(['bcnR4NYOw2o', 'de', 'test@test.at'])
+        ->once();
+
+    mockYouTubVideoCall();
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('youTubeIdOrUrl', $fullYoutubeUrl)
+        ->set('submittedByEmail', 'test@test.at')
+        ->set('languageCode', 'de')
+        ->call('submit');
+});
+
+it('calls the submit action with short youtube url', function () {
+    // Arrange
+    $shortYoutubeUrl = 'https://youtu.be/bcnR4NYOw2o';
+    $this->mock(SubmitStreamAction::class)
+        ->shouldReceive('handle')
+        ->withArgs(['bcnR4NYOw2o', 'de', 'test@test.at'])
+        ->once();
+
+    mockYouTubVideoCall();
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('youTubeIdOrUrl', $shortYoutubeUrl)
+        ->set('submittedByEmail', 'test@test.at')
+        ->set('languageCode', 'de')
+        ->call('submit');
+});
+
+it('shows a success message', function () {
+    // Arrange
+    mockYouTubVideoCall();
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('youTubeIdOrUrl', 'bcnR4NYOw2o')
+        ->set('submittedByEmail', 'test@test.at')
+        ->call('submit')
+        ->assertSee('You successfully submitted your stream. You will receive an email, if it gets approved.');
+});
+
+it('shows a success message with full youtube url too', function () {
+    // Arrange
+    $fullYoutubeUrl = 'https://www.youtube.com/watch?v=bcnR4NYOw2o';
+    mockYouTubVideoCall();
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('youTubeIdOrUrl', $fullYoutubeUrl)
+        ->set('submittedByEmail', 'test@test.at')
+        ->call('submit')
+        ->assertSee('You successfully submitted your stream. You will receive an email, if it gets approved.');
+});
+
+it('shows errors for wrong you tube url', function () {
+    // Arrange
+    mockYouTubVideoCall();
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('youTubeIdOrUrl', 'https://twitch.com/video?v=1')
+        ->call('submit')
+        ->assertSee('This is not a valid YouTube video ID/URL.');
+});
+
+test('the youtube id must be unique', function () {
+    // Arrange
+    Stream::factory()->create(['youtube_id' => 'bcnR4NYOw2o']);
+    mockYouTubVideoCall();
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('youTubeIdOrUrl', 'bcnR4NYOw2o')
+        ->call('submit')
+        ->assertSee('This stream was already submitted.');
+});
+
+test('the youtube id must be valid', function () {
+    // Arrange
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect());
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('submittedByEmail', 'test@test.at')
+        ->set('youTubeIdOrUrl', 'not-valid-video-id')
+        ->call('submit')
+        ->assertSee("We couldn't find a YouTube video for the ID: not-valid-video-id");
+});
+
+test('the planned stream start must be in the future', function () {
+    // Arrange
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(
+                videoId: 'bcnR4NYOw2o',
+                plannedStart: now()->subDay()
+            ),
+        ]));
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('submittedByEmail', 'test@test.at')
+        ->set('youTubeIdOrUrl', 'bcnR4NYOw2o')
+        ->call('submit')
+        ->assertSee('We only accept streams that have not started yet.');
+});
+
+it('clears out the form after submission', function () {
+    // Arrange
+    mockYouTubVideoCall();
+
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->set('youTubeIdOrUrl', 'bcnR4NYOw2o')
+        ->set('submittedByEmail', 'test@test.at')
+        ->set('languageCode', 'de')
+        ->call('submit')
+        ->assertSet('youTubeIdOrUrl', '')
+        ->assertSet('languageCode', 'en')
+        ->assertSet('submittedByEmail', '');
+});
+
+it('wires properties and methods', function () {
+    // Arrange & Act & Assert
+    Livewire::test(SubmitYouTubeLiveStream::class)
+        ->assertPropertyWired('youTubeIdOrUrl')
+        ->assertPropertyWired('submittedByEmail')
+        ->assertPropertyWired('languageCode')
+        ->assertMethodWiredToForm('submit');
+});
+
+// Helpers
+function mockYouTubVideoCall(string $videoId = 'bcnR4NYOw2o'): void
 {
-    /** @test */
-    public function it_calls_the_submit_action(): void
-    {
-        // Arrange
-        $this->mock(SubmitStreamAction::class)
-            ->shouldReceive('handle')
-            ->withArgs(['1234', 'de', 'test@test.at'])
-            ->once();
-
-        $this->mockYouTubVideoCall();
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('youTubeIdOrUrl', '1234')
-            ->set('submittedByEmail', 'test@test.at')
-            ->set('languageCode', 'de')
-            ->call('submit');
-    }
-
-    /** @test */
-    public function it_calls_the_submit_action_with_full_youtube_url(): void
-    {
-        // Arrange
-        $fullYoutubeUrl = 'https://www.youtube.com/watch?v=bcnR4NYOw2o';
-        $this->mock(SubmitStreamAction::class)
-            ->shouldReceive('handle')
-            ->withArgs(['bcnR4NYOw2o', 'de', 'test@test.at'])
-            ->once();
-
-        $this->mockYouTubVideoCall();
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('youTubeIdOrUrl', $fullYoutubeUrl)
-            ->set('submittedByEmail', 'test@test.at')
-            ->set('languageCode', 'de')
-            ->call('submit');
-    }
-
-    /** @test */
-    public function it_calls_the_submit_action_with_short_youtube_url(): void
-    {
-        // Arrange
-        $shortYoutubeUrl = 'https://youtu.be/bcnR4NYOw2o';
-        $this->mock(SubmitStreamAction::class)
-            ->shouldReceive('handle')
-            ->withArgs(['bcnR4NYOw2o', 'de', 'test@test.at'])
-            ->once();
-
-        $this->mockYouTubVideoCall();
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('youTubeIdOrUrl', $shortYoutubeUrl)
-            ->set('submittedByEmail', 'test@test.at')
-            ->set('languageCode', 'de')
-            ->call('submit');
-    }
-
-    /** @test */
-    public function it_shows_a_success_message(): void
-    {
-        // Arrange
-        $this->mockYouTubVideoCall();
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('youTubeIdOrUrl', 'bcnR4NYOw2o')
-            ->set('submittedByEmail', 'test@test.at')
-            ->call('submit')
-            ->assertSee('You successfully submitted your stream. You will receive an email, if it gets approved.');
-    }
-
-    /** @test */
-    public function it_shows_a_success_message_with_full_youtube_url_too(): void
-    {
-        // Arrange
-        $fullYoutubeUrl = 'https://www.youtube.com/watch?v=bcnR4NYOw2o';
-        $this->mockYouTubVideoCall();
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('youTubeIdOrUrl', $fullYoutubeUrl)
-            ->set('submittedByEmail', 'test@test.at')
-            ->call('submit')
-            ->assertSee('You successfully submitted your stream. You will receive an email, if it gets approved.');
-    }
-
-    /** @test */
-    public function it_shows_errors_for_wrong_youTube_url(): void
-    {
-        // Arrange
-        $this->mockYouTubVideoCall();
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('youTubeIdOrUrl', 'https://twitch.com/video?v=1')
-            ->call('submit')
-            ->assertSee('This is not a valid YouTube video ID/URL.');
-    }
-
-    /** @test */
-    public function the_youtubeId_must_be_unique(): void
-    {
-        // Arrange
-        Stream::factory()->create(['youtube_id' => 'bcnR4NYOw2o']);
-        $this->mockYouTubVideoCall();
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('youTubeIdOrUrl', 'bcnR4NYOw2o')
-            ->call('submit')
-            ->assertSee('This stream was already submitted.');
-    }
-
-    /** @test */
-    public function the_youtubeId_must_be_valid(): void
-    {
-        // Arrange
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect());
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('submittedByEmail', 'test@test.at')
-            ->set('youTubeIdOrUrl', 'not-valid-video-id')
-            ->call('submit')
-            ->assertSee("We couldn't find a YouTube video for the ID: not-valid-video-id");
-    }
-
-    /** @test */
-    public function the_planned_stream_start_must_be_in_the_future(): void
-    {
-        // Arrange
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(
-                    videoId: 'bcnR4NYOw2o',
-                    plannedStart: now()->subDay()
-                ),
-            ]));
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('submittedByEmail', 'test@test.at')
-            ->set('youTubeIdOrUrl', 'bcnR4NYOw2o')
-            ->call('submit')
-            ->assertSee('We only accept streams that have not started yet.');
-    }
-
-    /** @test */
-    public function it_clears_out_the_form_after_submission(): void
-    {
-        // Arrange
-        $this->mockYouTubVideoCall();
-
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->set('youTubeIdOrUrl', 'bcnR4NYOw2o')
-            ->set('submittedByEmail', 'test@test.at')
-            ->set('languageCode', 'de')
-            ->call('submit')
-            ->assertSet('youTubeIdOrUrl', '')
-            ->assertSet('languageCode', 'en')
-            ->assertSet('submittedByEmail', '');
-    }
-
-    /** @test */
-    public function it_wires_properties_and_methods(): void
-    {
-        // Arrange & Act & Assert
-        Livewire::test(SubmitYouTubeLiveStream::class)
-            ->assertPropertyWired('youTubeIdOrUrl')
-            ->assertPropertyWired('submittedByEmail')
-            ->assertPropertyWired('languageCode')
-            ->assertMethodWiredToForm('submit');
-    }
-
-    private function mockYouTubVideoCall(string $videoId = 'bcnR4NYOw2o'): void
-    {
-        YouTube::partialMock()
-            ->shouldReceive('videos')
-            ->andReturn(collect([
-                StreamData::fake(
-                    videoId: $videoId,
-                ),
-            ]));
-    }
+    YouTube::partialMock()
+        ->shouldReceive('videos')
+        ->andReturn(collect([
+            StreamData::fake(
+                videoId: $videoId,
+            ),
+        ]));
 }

--- a/tests/Feature/ImportChannelsForStreamsCommandTest.php
+++ b/tests/Feature/ImportChannelsForStreamsCommandTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Console\Commands\ImportChannelsForStreamsCommand;
 use App\Models\Channel;
 use App\Models\Stream;
@@ -9,117 +7,105 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-class ImportChannelsForStreamsCommandTest extends TestCase
-{
-    use YouTubeResponses;
+uses(TestCase::class);
+uses(YouTubeResponses::class);
 
-    /** @test */
-    public function it_imports_channel_for_stream(): void
-    {
-        Http::fake([
-            '*videos*' => Http::response($this->videoResponse()),
-            '*channels*' => Http::response($this->channelResponse()),
-        ]);
+it('imports channel for stream', function () {
+    Http::fake([
+        '*videos*' => Http::response($this->videoResponse()),
+        '*channels*' => Http::response($this->channelResponse()),
+    ]);
 
-        // Arrange
-        $stream1 = Stream::factory()
-            ->create(['youtube_id' => 'gzqJZQyfkaI']);
-        Stream::factory()
-            ->create(['youtube_id' => 'bcnR4NYOw2o']);
-        Stream::factory()
-            ->create(['youtube_id' => 'L3O1BbybSgw']);
+    // Arrange
+    $stream1 = Stream::factory()
+        ->create(['youtube_id' => 'gzqJZQyfkaI']);
+    Stream::factory()
+        ->create(['youtube_id' => 'bcnR4NYOw2o']);
+    Stream::factory()
+        ->create(['youtube_id' => 'L3O1BbybSgw']);
 
-        // Act
-        $this->artisan(ImportChannelsForStreamsCommand::class)
-            ->expectsOutput('Fetching 3 stream(s) from API to check for channel.');
+    // Act
+    $this->artisan(ImportChannelsForStreamsCommand::class)
+        ->expectsOutput('Fetching 3 stream(s) from API to check for channel.');
 
-        // Assert
-        $this->assertDatabaseHas(Channel::class, [
-            'platform_id' => 'UCdtd5QYBx9MUVXHm7qgEpxA',
-        ]);
+    // Assert
+    $this->assertDatabaseHas(Channel::class, [
+        'platform_id' => 'UCdtd5QYBx9MUVXHm7qgEpxA',
+    ]);
 
-        $stream1->refresh();
-        $this->assertEquals(1, $stream1->channel_id);
-    }
+    $stream1->refresh();
+    $this->assertEquals(1, $stream1->channel_id);
+});
 
-    /** @test */
-    public function it_imports_channel_for_specific_stream(): void
-    {
-        Http::fake([
-            '*videos*' => Http::response($this->singleVideoResponse()),
-            '*channels*' => Http::response($this->channelResponse()),
-        ]);
+it('imports channel for specific stream', function () {
+    Http::fake([
+        '*videos*' => Http::response($this->singleVideoResponse()),
+        '*channels*' => Http::response($this->channelResponse()),
+    ]);
 
-        // Arrange
-        $streamWithoutChannelToImport = Stream::factory()
-            ->create(['youtube_id' => 'gzqJZQyfkaI']);
-        Stream::factory()
-            ->create(['youtube_id' => 'bcnR4NYOw2o']);
+    // Arrange
+    $streamWithoutChannelToImport = Stream::factory()
+        ->create(['youtube_id' => 'gzqJZQyfkaI']);
+    Stream::factory()
+        ->create(['youtube_id' => 'bcnR4NYOw2o']);
 
-        // Act
-        $this->artisan(ImportChannelsForStreamsCommand::class, ['stream' => $streamWithoutChannelToImport])
-            ->expectsOutput('Fetching 1 stream(s) from API to check for channel.');
+    // Act
+    $this->artisan(ImportChannelsForStreamsCommand::class, ['stream' => $streamWithoutChannelToImport])
+        ->expectsOutput('Fetching 1 stream(s) from API to check for channel.');
 
-        // Assert
-        $this->assertDatabaseHas(Channel::class, [
-            'platform_id' => 'UCdtd5QYBx9MUVXHm7qgEpxA',
-        ]);
-    }
+    // Assert
+    $this->assertDatabaseHas(Channel::class, [
+        'platform_id' => 'UCdtd5QYBx9MUVXHm7qgEpxA',
+    ]);
+});
 
-    /** @test */
-    public function it_does_not_import_channel_for_pending_stream(): void
-    {
-        Http::fake();
+it('does not import channel for pending stream', function () {
+    Http::fake();
 
-        // Arrange
-        Stream::factory()
-            ->notApproved()
-            ->create(['youtube_id' => 'gzqJZQyfkaI']);
+    // Arrange
+    Stream::factory()
+        ->notApproved()
+        ->create(['youtube_id' => 'gzqJZQyfkaI']);
 
-        // Act & Assert
-        $this->artisan(ImportChannelsForStreamsCommand::class)
-            ->expectsOutput('There are no streams without a channel.')
-            ->assertExitCode(0);
+    // Act & Assert
+    $this->artisan(ImportChannelsForStreamsCommand::class)
+        ->expectsOutput('There are no streams without a channel.')
+        ->assertExitCode(0);
 
-        Http::assertNothingSent();
-    }
+    Http::assertNothingSent();
+});
 
-    /** @test */
-    public function it_updates_channel_if_already_given(): void
-    {
-        Http::fake([
-            '*videos*' => Http::response($this->singleVideoResponse()),
-            '*channels*' => Http::response($this->channelResponse()),
-        ]);
+it('updates channel if already given', function () {
+    Http::fake([
+        '*videos*' => Http::response($this->singleVideoResponse()),
+        '*channels*' => Http::response($this->channelResponse()),
+    ]);
 
-        // Arrange
-        Channel::factory()
-            ->create(['platform_id' => 'UCdtd5QYBx9MUVXHm7qgEpxA']);
-        Stream::factory()
-            ->approved()
-            ->create(['channel_id' => null, 'youtube_id' => 'gzqJZQyfkaI']);
+    // Arrange
+    Channel::factory()
+        ->create(['platform_id' => 'UCdtd5QYBx9MUVXHm7qgEpxA']);
+    Stream::factory()
+        ->approved()
+        ->create(['channel_id' => null, 'youtube_id' => 'gzqJZQyfkaI']);
 
-        // Act & Assert
-        $this->artisan(ImportChannelsForStreamsCommand::class);
+    // Act & Assert
+    $this->artisan(ImportChannelsForStreamsCommand::class);
 
-        $this->assertDatabaseCount(Channel::class, 1);
-    }
+    $this->assertDatabaseCount(Channel::class, 1);
+});
 
-    /** @test */
-    public function it_does_not_call_youtube_if_all_channels_given(): void
-    {
-        // Arrange
-        Http::fake();
-        Stream::factory()
-            ->for(Channel::factory())
-            ->create();
+it('does not call youtube if all channels given', function () {
+    // Arrange
+    Http::fake();
+    Stream::factory()
+        ->for(Channel::factory())
+        ->create();
 
-        // Act
-        $this->artisan(ImportChannelsForStreamsCommand::class)
-            ->expectsOutput('There are no streams without a channel.')
-            ->assertExitCode(0);
+    // Act
+    $this->artisan(ImportChannelsForStreamsCommand::class)
+        ->expectsOutput('There are no streams without a channel.')
+        ->assertExitCode(0);
 
-        // Assert
-        Http::assertNothingSent();
-    }
-}
+    // Assert
+    Http::assertNothingSent();
+});

--- a/tests/Feature/ImportChannelsForStreamsCommandTest.php
+++ b/tests/Feature/ImportChannelsForStreamsCommandTest.php
@@ -34,7 +34,7 @@ it('imports channel for stream', function () {
     ]);
 
     $stream1->refresh();
-    $this->assertEquals(1, $stream1->channel_id);
+    expect($stream1->channel_id)->toEqual(1);
 });
 
 it('imports channel for specific stream', function () {

--- a/tests/Feature/ImportChannelsForStreamsCommandTest.php
+++ b/tests/Feature/ImportChannelsForStreamsCommandTest.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-uses(TestCase::class);
 uses(YouTubeResponses::class);
 
 it('imports channel for stream', function () {

--- a/tests/Feature/JetStream/ApiTokenPermissionsTest.php
+++ b/tests/Feature/JetStream/ApiTokenPermissionsTest.php
@@ -7,7 +7,6 @@ use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('api token permissions can be updated', function () {
     if (! Features::hasApiFeatures()) {

--- a/tests/Feature/JetStream/ApiTokenPermissionsTest.php
+++ b/tests/Feature/JetStream/ApiTokenPermissionsTest.php
@@ -36,7 +36,7 @@ test('api token permissions can be updated', function () {
                 ]])
                 ->call('updateApiToken');
 
-    $this->assertTrue($user->fresh()->tokens->first()->can('delete'));
-    $this->assertFalse($user->fresh()->tokens->first()->can('read'));
-    $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+    expect($user->fresh()->tokens->first()->can('delete'))->toBeTrue();
+    expect($user->fresh()->tokens->first()->can('read'))->toBeFalse();
+    expect($user->fresh()->tokens->first()->can('missing-permission'))->toBeFalse();
 });

--- a/tests/Feature/JetStream/ApiTokenPermissionsTest.php
+++ b/tests/Feature/JetStream/ApiTokenPermissionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Features;
@@ -9,38 +7,36 @@ use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class ApiTokenPermissionsTest extends TestCase
-{
-    public function test_api_token_permissions_can_be_updated()
-    {
-        if (! Features::hasApiFeatures()) {
-            return $this->markTestSkipped('API support is not enabled.');
-        }
+uses(TestCase::class);
 
-        if (Features::hasTeamFeatures()) {
-            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
-        } else {
-            $this->actingAs($user = User::factory()->create());
-        }
-
-        $token = $user->tokens()->create([
-            'name' => 'Test Token',
-            'token' => Str::random(40),
-            'abilities' => ['create', 'read'],
-        ]);
-
-        Livewire::test(ApiTokenManager::class)
-                    ->set(['managingPermissionsFor' => $token])
-                    ->set(['updateApiTokenForm' => [
-                        'permissions' => [
-                            'delete',
-                            'missing-permission',
-                        ],
-                    ]])
-                    ->call('updateApiToken');
-
-        $this->assertTrue($user->fresh()->tokens->first()->can('delete'));
-        $this->assertFalse($user->fresh()->tokens->first()->can('read'));
-        $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+test('api token permissions can be updated', function () {
+    if (! Features::hasApiFeatures()) {
+        return $this->markTestSkipped('API support is not enabled.');
     }
-}
+
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $token = $user->tokens()->create([
+        'name' => 'Test Token',
+        'token' => Str::random(40),
+        'abilities' => ['create', 'read'],
+    ]);
+
+    Livewire::test(ApiTokenManager::class)
+                ->set(['managingPermissionsFor' => $token])
+                ->set(['updateApiTokenForm' => [
+                    'permissions' => [
+                        'delete',
+                        'missing-permission',
+                    ],
+                ]])
+                ->call('updateApiToken');
+
+    $this->assertTrue($user->fresh()->tokens->first()->can('delete'));
+    $this->assertFalse($user->fresh()->tokens->first()->can('read'));
+    $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+});

--- a/tests/Feature/JetStream/AuthenticationTest.php
+++ b/tests/Feature/JetStream/AuthenticationTest.php
@@ -4,7 +4,6 @@ use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('login screen can be rendered', function () {
     $response = $this->get('/login');

--- a/tests/Feature/JetStream/AuthenticationTest.php
+++ b/tests/Feature/JetStream/AuthenticationTest.php
@@ -1,42 +1,36 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Tests\TestCase;
 
-class AuthenticationTest extends TestCase
-{
-    public function test_login_screen_can_be_rendered()
-    {
-        $response = $this->get('/login');
+uses(TestCase::class);
 
-        $response->assertStatus(200);
-    }
+test('login screen can be rendered', function () {
+    $response = $this->get('/login');
 
-    public function test_users_can_authenticate_using_the_login_screen()
-    {
-        $user = User::factory()->create();
+    $response->assertStatus(200);
+});
 
-        $response = $this->post('/login', [
-            'email' => $user->email,
-            'password' => 'password',
-        ]);
+test('users can authenticate using the login screen', function () {
+    $user = User::factory()->create();
 
-        $this->assertAuthenticated();
-        $response->assertRedirect(RouteServiceProvider::HOME);
-    }
+    $response = $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
 
-    public function test_users_can_not_authenticate_with_invalid_password()
-    {
-        $user = User::factory()->create();
+    $this->assertAuthenticated();
+    $response->assertRedirect(RouteServiceProvider::HOME);
+});
 
-        $this->post('/login', [
-            'email' => $user->email,
-            'password' => 'wrong-password',
-        ]);
+test('users can not authenticate with invalid password', function () {
+    $user = User::factory()->create();
 
-        $this->assertGuest();
-    }
-}
+    $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'wrong-password',
+    ]);
+
+    $this->assertGuest();
+});

--- a/tests/Feature/JetStream/BrowserSessionsTest.php
+++ b/tests/Feature/JetStream/BrowserSessionsTest.php
@@ -1,20 +1,16 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Laravel\Jetstream\Http\Livewire\LogoutOtherBrowserSessionsForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class BrowserSessionsTest extends TestCase
-{
-    public function test_other_browser_sessions_can_be_logged_out()
-    {
-        $this->actingAs($user = User::factory()->create());
+uses(TestCase::class);
 
-        Livewire::test(LogoutOtherBrowserSessionsForm::class)
-                ->set('password', 'password')
-                ->call('logoutOtherBrowserSessions');
-    }
-}
+test('other browser sessions can be logged out', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    Livewire::test(LogoutOtherBrowserSessionsForm::class)
+            ->set('password', 'password')
+            ->call('logoutOtherBrowserSessions');
+});

--- a/tests/Feature/JetStream/BrowserSessionsTest.php
+++ b/tests/Feature/JetStream/BrowserSessionsTest.php
@@ -5,7 +5,6 @@ use Laravel\Jetstream\Http\Livewire\LogoutOtherBrowserSessionsForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('other browser sessions can be logged out', function () {
     $this->actingAs($user = User::factory()->create());

--- a/tests/Feature/JetStream/CreateApiTokenTest.php
+++ b/tests/Feature/JetStream/CreateApiTokenTest.php
@@ -1,40 +1,36 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class CreateApiTokenTest extends TestCase
-{
-    public function test_api_tokens_can_be_created()
-    {
-        if (! Features::hasApiFeatures()) {
-            return $this->markTestSkipped('API support is not enabled.');
-        }
+uses(TestCase::class);
 
-        if (Features::hasTeamFeatures()) {
-            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
-        } else {
-            $this->actingAs($user = User::factory()->create());
-        }
-
-        Livewire::test(ApiTokenManager::class)
-                    ->set(['createApiTokenForm' => [
-                        'name' => 'Test Token',
-                        'permissions' => [
-                            'read',
-                            'update',
-                        ],
-                    ]])
-                    ->call('createApiToken');
-
-        $this->assertCount(1, $user->fresh()->tokens);
-        $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
-        $this->assertTrue($user->fresh()->tokens->first()->can('read'));
-        $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+test('api tokens can be created', function () {
+    if (! Features::hasApiFeatures()) {
+        return $this->markTestSkipped('API support is not enabled.');
     }
-}
+
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    Livewire::test(ApiTokenManager::class)
+                ->set(['createApiTokenForm' => [
+                    'name' => 'Test Token',
+                    'permissions' => [
+                        'read',
+                        'update',
+                    ],
+                ]])
+                ->call('createApiToken');
+
+    $this->assertCount(1, $user->fresh()->tokens);
+    $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
+    $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+    $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+});

--- a/tests/Feature/JetStream/CreateApiTokenTest.php
+++ b/tests/Feature/JetStream/CreateApiTokenTest.php
@@ -6,7 +6,6 @@ use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('api tokens can be created', function () {
     if (! Features::hasApiFeatures()) {

--- a/tests/Feature/JetStream/CreateApiTokenTest.php
+++ b/tests/Feature/JetStream/CreateApiTokenTest.php
@@ -29,8 +29,8 @@ test('api tokens can be created', function () {
                 ]])
                 ->call('createApiToken');
 
-    $this->assertCount(1, $user->fresh()->tokens);
-    $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
-    $this->assertTrue($user->fresh()->tokens->first()->can('read'));
-    $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first()->name)->toEqual('Test Token');
+    expect($user->fresh()->tokens->first()->can('read'))->toBeTrue();
+    expect($user->fresh()->tokens->first()->can('delete'))->toBeFalse();
 });

--- a/tests/Feature/JetStream/DeleteAccountTest.php
+++ b/tests/Feature/JetStream/DeleteAccountTest.php
@@ -1,43 +1,38 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\DeleteUserForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class DeleteAccountTest extends TestCase
-{
-    public function test_user_accounts_can_be_deleted()
-    {
-        if (! Features::hasAccountDeletionFeatures()) {
-            return $this->markTestSkipped('Account deletion is not enabled.');
-        }
+uses(TestCase::class);
 
-        $this->actingAs($user = User::factory()->create());
-
-        $component = Livewire::test(DeleteUserForm::class)
-                        ->set('password', 'password')
-                        ->call('deleteUser');
-
-        $this->assertNull($user->fresh());
+test('user accounts can be deleted', function () {
+    if (! Features::hasAccountDeletionFeatures()) {
+        return $this->markTestSkipped('Account deletion is not enabled.');
     }
 
-    public function test_correct_password_must_be_provided_before_account_can_be_deleted()
-    {
-        if (! Features::hasAccountDeletionFeatures()) {
-            return $this->markTestSkipped('Account deletion is not enabled.');
-        }
+    $this->actingAs($user = User::factory()->create());
 
-        $this->actingAs($user = User::factory()->create());
+    $component = Livewire::test(DeleteUserForm::class)
+                    ->set('password', 'password')
+                    ->call('deleteUser');
 
-        Livewire::test(DeleteUserForm::class)
-                        ->set('password', 'wrong-password')
-                        ->call('deleteUser')
-                        ->assertHasErrors(['password']);
+    $this->assertNull($user->fresh());
+});
 
-        $this->assertNotNull($user->fresh());
+test('correct password must be provided before account can be deleted', function () {
+    if (! Features::hasAccountDeletionFeatures()) {
+        return $this->markTestSkipped('Account deletion is not enabled.');
     }
-}
+
+    $this->actingAs($user = User::factory()->create());
+
+    Livewire::test(DeleteUserForm::class)
+                    ->set('password', 'wrong-password')
+                    ->call('deleteUser')
+                    ->assertHasErrors(['password']);
+
+    $this->assertNotNull($user->fresh());
+});

--- a/tests/Feature/JetStream/DeleteAccountTest.php
+++ b/tests/Feature/JetStream/DeleteAccountTest.php
@@ -6,7 +6,6 @@ use Laravel\Jetstream\Http\Livewire\DeleteUserForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('user accounts can be deleted', function () {
     if (! Features::hasAccountDeletionFeatures()) {

--- a/tests/Feature/JetStream/DeleteAccountTest.php
+++ b/tests/Feature/JetStream/DeleteAccountTest.php
@@ -19,7 +19,7 @@ test('user accounts can be deleted', function () {
                     ->set('password', 'password')
                     ->call('deleteUser');
 
-    $this->assertNull($user->fresh());
+    expect($user->fresh())->toBeNull();
 });
 
 test('correct password must be provided before account can be deleted', function () {

--- a/tests/Feature/JetStream/DeleteApiTokenTest.php
+++ b/tests/Feature/JetStream/DeleteApiTokenTest.php
@@ -7,7 +7,6 @@ use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('api tokens can be deleted', function () {
     if (! Features::hasApiFeatures()) {

--- a/tests/Feature/JetStream/DeleteApiTokenTest.php
+++ b/tests/Feature/JetStream/DeleteApiTokenTest.php
@@ -30,5 +30,5 @@ test('api tokens can be deleted', function () {
                 ->set(['apiTokenIdBeingDeleted' => $token->id])
                 ->call('deleteApiToken');
 
-    $this->assertCount(0, $user->fresh()->tokens);
+    expect($user->fresh()->tokens)->toHaveCount(0);
 });

--- a/tests/Feature/JetStream/DeleteApiTokenTest.php
+++ b/tests/Feature/JetStream/DeleteApiTokenTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Features;
@@ -9,30 +7,28 @@ use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class DeleteApiTokenTest extends TestCase
-{
-    public function test_api_tokens_can_be_deleted()
-    {
-        if (! Features::hasApiFeatures()) {
-            return $this->markTestSkipped('API support is not enabled.');
-        }
+uses(TestCase::class);
 
-        if (Features::hasTeamFeatures()) {
-            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
-        } else {
-            $this->actingAs($user = User::factory()->create());
-        }
-
-        $token = $user->tokens()->create([
-            'name' => 'Test Token',
-            'token' => Str::random(40),
-            'abilities' => ['create', 'read'],
-        ]);
-
-        Livewire::test(ApiTokenManager::class)
-                    ->set(['apiTokenIdBeingDeleted' => $token->id])
-                    ->call('deleteApiToken');
-
-        $this->assertCount(0, $user->fresh()->tokens);
+test('api tokens can be deleted', function () {
+    if (! Features::hasApiFeatures()) {
+        return $this->markTestSkipped('API support is not enabled.');
     }
-}
+
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $token = $user->tokens()->create([
+        'name' => 'Test Token',
+        'token' => Str::random(40),
+        'abilities' => ['create', 'read'],
+    ]);
+
+    Livewire::test(ApiTokenManager::class)
+                ->set(['apiTokenIdBeingDeleted' => $token->id])
+                ->call('deleteApiToken');
+
+    $this->assertCount(0, $user->fresh()->tokens);
+});

--- a/tests/Feature/JetStream/EmailVerificationTest.php
+++ b/tests/Feature/JetStream/EmailVerificationTest.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\URL;
 use Laravel\Fortify\Features;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('email verification screen can be rendered', function () {
     if (! Features::enabled(Features::emailVerification())) {

--- a/tests/Feature/JetStream/EmailVerificationTest.php
+++ b/tests/Feature/JetStream/EmailVerificationTest.php
@@ -45,7 +45,7 @@ test('email can be verified', function () {
 
     Event::assertDispatched(Verified::class);
 
-    $this->assertTrue($user->fresh()->hasVerifiedEmail());
+    expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
     $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
 });
 
@@ -66,5 +66,5 @@ test('email can not verified with invalid hash', function () {
 
     $this->actingAs($user)->get($verificationUrl);
 
-    $this->assertFalse($user->fresh()->hasVerifiedEmail());
+    expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
 });

--- a/tests/Feature/JetStream/EmailVerificationTest.php
+++ b/tests/Feature/JetStream/EmailVerificationTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Auth\Events\Verified;
@@ -10,67 +8,63 @@ use Illuminate\Support\Facades\URL;
 use Laravel\Fortify\Features;
 use Tests\TestCase;
 
-class EmailVerificationTest extends TestCase
-{
-    public function test_email_verification_screen_can_be_rendered()
-    {
-        if (! Features::enabled(Features::emailVerification())) {
-            return $this->markTestSkipped('Email verification not enabled.');
-        }
+uses(TestCase::class);
 
-        $user = User::factory()->withPersonalTeam()->create([
-            'email_verified_at' => null,
-        ]);
-
-        $response = $this->actingAs($user)->get('/email/verify');
-
-        $response->assertStatus(200);
+test('email verification screen can be rendered', function () {
+    if (! Features::enabled(Features::emailVerification())) {
+        return $this->markTestSkipped('Email verification not enabled.');
     }
 
-    public function test_email_can_be_verified()
-    {
-        if (! Features::enabled(Features::emailVerification())) {
-            return $this->markTestSkipped('Email verification not enabled.');
-        }
+    $user = User::factory()->withPersonalTeam()->create([
+        'email_verified_at' => null,
+    ]);
 
-        Event::fake();
+    $response = $this->actingAs($user)->get('/email/verify');
 
-        $user = User::factory()->create([
-            'email_verified_at' => null,
-        ]);
+    $response->assertStatus(200);
+});
 
-        $verificationUrl = URL::temporarySignedRoute(
-            'verification.verify',
-            now()->addMinutes(60),
-            ['id' => $user->id, 'hash' => sha1($user->email)]
-        );
-
-        $response = $this->actingAs($user)->get($verificationUrl);
-
-        Event::assertDispatched(Verified::class);
-
-        $this->assertTrue($user->fresh()->hasVerifiedEmail());
-        $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
+test('email can be verified', function () {
+    if (! Features::enabled(Features::emailVerification())) {
+        return $this->markTestSkipped('Email verification not enabled.');
     }
 
-    public function test_email_can_not_verified_with_invalid_hash()
-    {
-        if (! Features::enabled(Features::emailVerification())) {
-            return $this->markTestSkipped('Email verification not enabled.');
-        }
+    Event::fake();
 
-        $user = User::factory()->create([
-            'email_verified_at' => null,
-        ]);
+    $user = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
 
-        $verificationUrl = URL::temporarySignedRoute(
-            'verification.verify',
-            now()->addMinutes(60),
-            ['id' => $user->id, 'hash' => sha1('wrong-email')]
-        );
+    $verificationUrl = URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        ['id' => $user->id, 'hash' => sha1($user->email)]
+    );
 
-        $this->actingAs($user)->get($verificationUrl);
+    $response = $this->actingAs($user)->get($verificationUrl);
 
-        $this->assertFalse($user->fresh()->hasVerifiedEmail());
+    Event::assertDispatched(Verified::class);
+
+    $this->assertTrue($user->fresh()->hasVerifiedEmail());
+    $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
+});
+
+test('email can not verified with invalid hash', function () {
+    if (! Features::enabled(Features::emailVerification())) {
+        return $this->markTestSkipped('Email verification not enabled.');
     }
-}
+
+    $user = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    $verificationUrl = URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        ['id' => $user->id, 'hash' => sha1('wrong-email')]
+    );
+
+    $this->actingAs($user)->get($verificationUrl);
+
+    $this->assertFalse($user->fresh()->hasVerifiedEmail());
+});

--- a/tests/Feature/JetStream/PasswordConfirmationTest.php
+++ b/tests/Feature/JetStream/PasswordConfirmationTest.php
@@ -1,44 +1,38 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
-class PasswordConfirmationTest extends TestCase
-{
-    public function test_confirm_password_screen_can_be_rendered()
-    {
-        $user = Features::hasTeamFeatures()
-                        ? User::factory()->withPersonalTeam()->create()
-                        : User::factory()->create();
+uses(TestCase::class);
 
-        $response = $this->actingAs($user)->get('/user/confirm-password');
+test('confirm password screen can be rendered', function () {
+    $user = Features::hasTeamFeatures()
+                    ? User::factory()->withPersonalTeam()->create()
+                    : User::factory()->create();
 
-        $response->assertStatus(200);
-    }
+    $response = $this->actingAs($user)->get('/user/confirm-password');
 
-    public function test_password_can_be_confirmed()
-    {
-        $user = User::factory()->create();
+    $response->assertStatus(200);
+});
 
-        $response = $this->actingAs($user)->post('/user/confirm-password', [
-            'password' => 'password',
-        ]);
+test('password can be confirmed', function () {
+    $user = User::factory()->create();
 
-        $response->assertRedirect();
-        $response->assertSessionHasNoErrors();
-    }
+    $response = $this->actingAs($user)->post('/user/confirm-password', [
+        'password' => 'password',
+    ]);
 
-    public function test_password_is_not_confirmed_with_invalid_password()
-    {
-        $user = User::factory()->create();
+    $response->assertRedirect();
+    $response->assertSessionHasNoErrors();
+});
 
-        $response = $this->actingAs($user)->post('/user/confirm-password', [
-            'password' => 'wrong-password',
-        ]);
+test('password is not confirmed with invalid password', function () {
+    $user = User::factory()->create();
 
-        $response->assertSessionHasErrors();
-    }
-}
+    $response = $this->actingAs($user)->post('/user/confirm-password', [
+        'password' => 'wrong-password',
+    ]);
+
+    $response->assertSessionHasErrors();
+});

--- a/tests/Feature/JetStream/PasswordConfirmationTest.php
+++ b/tests/Feature/JetStream/PasswordConfirmationTest.php
@@ -4,7 +4,6 @@ use App\Models\User;
 use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('confirm password screen can be rendered', function () {
     $user = Features::hasTeamFeatures()

--- a/tests/Feature/JetStream/PasswordResetTest.php
+++ b/tests/Feature/JetStream/PasswordResetTest.php
@@ -5,7 +5,6 @@ use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('reset password link screen can be rendered', function () {
     $response = $this->get('/forgot-password');

--- a/tests/Feature/JetStream/PasswordResetTest.php
+++ b/tests/Feature/JetStream/PasswordResetTest.php
@@ -1,74 +1,67 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
-class PasswordResetTest extends TestCase
-{
-    public function test_reset_password_link_screen_can_be_rendered()
-    {
-        $response = $this->get('/forgot-password');
+uses(TestCase::class);
+
+test('reset password link screen can be rendered', function () {
+    $response = $this->get('/forgot-password');
+
+    $response->assertStatus(200);
+});
+
+test('reset password link can be requested', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $response = $this->post('/forgot-password', [
+        'email' => $user->email,
+    ]);
+
+    Notification::assertSentTo($user, ResetPassword::class);
+});
+
+test('reset password screen can be rendered', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $response = $this->post('/forgot-password', [
+        'email' => $user->email,
+    ]);
+
+    Notification::assertSentTo($user, ResetPassword::class, function($notification) {
+        $response = $this->get('/reset-password/'.$notification->token);
 
         $response->assertStatus(200);
-    }
 
-    public function test_reset_password_link_can_be_requested()
-    {
-        Notification::fake();
+        return true;
+    });
+});
 
-        $user = User::factory()->create();
+test('password can be reset with valid token', function () {
+    Notification::fake();
 
-        $response = $this->post('/forgot-password', [
+    $user = User::factory()->create();
+
+    $response = $this->post('/forgot-password', [
+        'email' => $user->email,
+    ]);
+
+    Notification::assertSentTo($user, ResetPassword::class, function($notification) use ($user) {
+        $response = $this->post('/reset-password', [
+            'token' => $notification->token,
             'email' => $user->email,
+            'password' => 'password',
+            'password_confirmation' => 'password',
         ]);
 
-        Notification::assertSentTo($user, ResetPassword::class);
-    }
+        $response->assertSessionHasNoErrors();
 
-    public function test_reset_password_screen_can_be_rendered()
-    {
-        Notification::fake();
-
-        $user = User::factory()->create();
-
-        $response = $this->post('/forgot-password', [
-            'email' => $user->email,
-        ]);
-
-        Notification::assertSentTo($user, ResetPassword::class, function($notification) {
-            $response = $this->get('/reset-password/'.$notification->token);
-
-            $response->assertStatus(200);
-
-            return true;
-        });
-    }
-
-    public function test_password_can_be_reset_with_valid_token()
-    {
-        Notification::fake();
-
-        $user = User::factory()->create();
-
-        $response = $this->post('/forgot-password', [
-            'email' => $user->email,
-        ]);
-
-        Notification::assertSentTo($user, ResetPassword::class, function($notification) use ($user) {
-            $response = $this->post('/reset-password', [
-                'token' => $notification->token,
-                'email' => $user->email,
-                'password' => 'password',
-                'password_confirmation' => 'password',
-            ]);
-
-            $response->assertSessionHasNoErrors();
-
-            return true;
-        });
-    }
-}
+        return true;
+    });
+});

--- a/tests/Feature/JetStream/ProfileInformationTest.php
+++ b/tests/Feature/JetStream/ProfileInformationTest.php
@@ -1,33 +1,28 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class ProfileInformationTest extends TestCase
-{
-    public function test_current_profile_information_is_available()
-    {
-        $this->actingAs($user = User::factory()->create());
+uses(TestCase::class);
 
-        $component = Livewire::test(UpdateProfileInformationForm::class);
+test('current profile information is available', function () {
+    $this->actingAs($user = User::factory()->create());
 
-        $this->assertEquals($user->name, $component->state['name']);
-        $this->assertEquals($user->email, $component->state['email']);
-    }
+    $component = Livewire::test(UpdateProfileInformationForm::class);
 
-    public function test_profile_information_can_be_updated()
-    {
-        $this->actingAs($user = User::factory()->create());
+    $this->assertEquals($user->name, $component->state['name']);
+    $this->assertEquals($user->email, $component->state['email']);
+});
 
-        Livewire::test(UpdateProfileInformationForm::class)
-                ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])
-                ->call('updateProfileInformation');
+test('profile information can be updated', function () {
+    $this->actingAs($user = User::factory()->create());
 
-        $this->assertEquals('Test Name', $user->fresh()->name);
-        $this->assertEquals('test@example.com', $user->fresh()->email);
-    }
-}
+    Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])
+            ->call('updateProfileInformation');
+
+    $this->assertEquals('Test Name', $user->fresh()->name);
+    $this->assertEquals('test@example.com', $user->fresh()->email);
+});

--- a/tests/Feature/JetStream/ProfileInformationTest.php
+++ b/tests/Feature/JetStream/ProfileInformationTest.php
@@ -5,7 +5,6 @@ use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('current profile information is available', function () {
     $this->actingAs($user = User::factory()->create());

--- a/tests/Feature/JetStream/ProfileInformationTest.php
+++ b/tests/Feature/JetStream/ProfileInformationTest.php
@@ -12,8 +12,8 @@ test('current profile information is available', function () {
 
     $component = Livewire::test(UpdateProfileInformationForm::class);
 
-    $this->assertEquals($user->name, $component->state['name']);
-    $this->assertEquals($user->email, $component->state['email']);
+    expect($component->state['name'])->toEqual($user->name);
+    expect($component->state['email'])->toEqual($user->email);
 });
 
 test('profile information can be updated', function () {
@@ -23,6 +23,6 @@ test('profile information can be updated', function () {
             ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])
             ->call('updateProfileInformation');
 
-    $this->assertEquals('Test Name', $user->fresh()->name);
-    $this->assertEquals('test@example.com', $user->fresh()->email);
+    expect($user->fresh()->name)->toEqual('Test Name');
+    expect($user->fresh()->email)->toEqual('test@example.com');
 });

--- a/tests/Feature/JetStream/TwoFactorAuthenticationSettingsTest.php
+++ b/tests/Feature/JetStream/TwoFactorAuthenticationSettingsTest.php
@@ -5,7 +5,6 @@ use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('two factor authentication can be enabled', function () {
     $this->actingAs($user = User::factory()->create());

--- a/tests/Feature/JetStream/TwoFactorAuthenticationSettingsTest.php
+++ b/tests/Feature/JetStream/TwoFactorAuthenticationSettingsTest.php
@@ -18,7 +18,7 @@ test('two factor authentication can be enabled', function () {
     $user = $user->fresh();
 
     $this->assertNotNull($user->two_factor_secret);
-    $this->assertCount(8, $user->recoveryCodes());
+    expect($user->recoveryCodes())->toHaveCount(8);
 });
 
 test('recovery codes can be regenerated', function () {
@@ -34,8 +34,8 @@ test('recovery codes can be regenerated', function () {
 
     $component->call('regenerateRecoveryCodes');
 
-    $this->assertCount(8, $user->recoveryCodes());
-    $this->assertCount(8, array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()));
+    expect($user->recoveryCodes())->toHaveCount(8);
+    expect(array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()))->toHaveCount(8);
 });
 
 test('two factor authentication can be disabled', function () {
@@ -50,5 +50,5 @@ test('two factor authentication can be disabled', function () {
 
     $component->call('disableTwoFactorAuthentication');
 
-    $this->assertNull($user->fresh()->two_factor_secret);
+    expect($user->fresh()->two_factor_secret)->toBeNull();
 });

--- a/tests/Feature/JetStream/TwoFactorAuthenticationSettingsTest.php
+++ b/tests/Feature/JetStream/TwoFactorAuthenticationSettingsTest.php
@@ -1,60 +1,54 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class TwoFactorAuthenticationSettingsTest extends TestCase
-{
-    public function test_two_factor_authentication_can_be_enabled()
-    {
-        $this->actingAs($user = User::factory()->create());
+uses(TestCase::class);
 
-        $this->withSession(['auth.password_confirmed_at' => time()]);
+test('two factor authentication can be enabled', function () {
+    $this->actingAs($user = User::factory()->create());
 
-        Livewire::test(TwoFactorAuthenticationForm::class)
-                ->call('enableTwoFactorAuthentication');
+    $this->withSession(['auth.password_confirmed_at' => time()]);
 
-        $user = $user->fresh();
+    Livewire::test(TwoFactorAuthenticationForm::class)
+            ->call('enableTwoFactorAuthentication');
 
-        $this->assertNotNull($user->two_factor_secret);
-        $this->assertCount(8, $user->recoveryCodes());
-    }
+    $user = $user->fresh();
 
-    public function test_recovery_codes_can_be_regenerated()
-    {
-        $this->actingAs($user = User::factory()->create());
+    $this->assertNotNull($user->two_factor_secret);
+    $this->assertCount(8, $user->recoveryCodes());
+});
 
-        $this->withSession(['auth.password_confirmed_at' => time()]);
+test('recovery codes can be regenerated', function () {
+    $this->actingAs($user = User::factory()->create());
 
-        $component = Livewire::test(TwoFactorAuthenticationForm::class)
-                ->call('enableTwoFactorAuthentication')
-                ->call('regenerateRecoveryCodes');
+    $this->withSession(['auth.password_confirmed_at' => time()]);
 
-        $user = $user->fresh();
+    $component = Livewire::test(TwoFactorAuthenticationForm::class)
+            ->call('enableTwoFactorAuthentication')
+            ->call('regenerateRecoveryCodes');
 
-        $component->call('regenerateRecoveryCodes');
+    $user = $user->fresh();
 
-        $this->assertCount(8, $user->recoveryCodes());
-        $this->assertCount(8, array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()));
-    }
+    $component->call('regenerateRecoveryCodes');
 
-    public function test_two_factor_authentication_can_be_disabled()
-    {
-        $this->actingAs($user = User::factory()->create());
+    $this->assertCount(8, $user->recoveryCodes());
+    $this->assertCount(8, array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()));
+});
 
-        $this->withSession(['auth.password_confirmed_at' => time()]);
+test('two factor authentication can be disabled', function () {
+    $this->actingAs($user = User::factory()->create());
 
-        $component = Livewire::test(TwoFactorAuthenticationForm::class)
-                ->call('enableTwoFactorAuthentication');
+    $this->withSession(['auth.password_confirmed_at' => time()]);
 
-        $this->assertNotNull($user->fresh()->two_factor_secret);
+    $component = Livewire::test(TwoFactorAuthenticationForm::class)
+            ->call('enableTwoFactorAuthentication');
 
-        $component->call('disableTwoFactorAuthentication');
+    $this->assertNotNull($user->fresh()->two_factor_secret);
 
-        $this->assertNull($user->fresh()->two_factor_secret);
-    }
-}
+    $component->call('disableTwoFactorAuthentication');
+
+    $this->assertNull($user->fresh()->two_factor_secret);
+});

--- a/tests/Feature/JetStream/UpdatePasswordTest.php
+++ b/tests/Feature/JetStream/UpdatePasswordTest.php
@@ -1,59 +1,53 @@
 <?php
 
-namespace Tests\Feature\JetStream;
-
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class UpdatePasswordTest extends TestCase
-{
-    public function test_password_can_be_updated()
-    {
-        $this->actingAs($user = User::factory()->create());
+uses(TestCase::class);
 
-        Livewire::test(UpdatePasswordForm::class)
-                ->set('state', [
-                    'current_password' => 'password',
-                    'password' => 'new-password',
-                    'password_confirmation' => 'new-password',
-                ])
-                ->call('updatePassword');
+test('password can be updated', function () {
+    $this->actingAs($user = User::factory()->create());
 
-        $this->assertTrue(Hash::check('new-password', $user->fresh()->password));
-    }
+    Livewire::test(UpdatePasswordForm::class)
+            ->set('state', [
+                'current_password' => 'password',
+                'password' => 'new-password',
+                'password_confirmation' => 'new-password',
+            ])
+            ->call('updatePassword');
 
-    public function test_current_password_must_be_correct()
-    {
-        $this->actingAs($user = User::factory()->create());
+    $this->assertTrue(Hash::check('new-password', $user->fresh()->password));
+});
 
-        Livewire::test(UpdatePasswordForm::class)
-                ->set('state', [
-                    'current_password' => 'wrong-password',
-                    'password' => 'new-password',
-                    'password_confirmation' => 'new-password',
-                ])
-                ->call('updatePassword')
-                ->assertHasErrors(['current_password']);
+test('current password must be correct', function () {
+    $this->actingAs($user = User::factory()->create());
 
-        $this->assertTrue(Hash::check('password', $user->fresh()->password));
-    }
+    Livewire::test(UpdatePasswordForm::class)
+            ->set('state', [
+                'current_password' => 'wrong-password',
+                'password' => 'new-password',
+                'password_confirmation' => 'new-password',
+            ])
+            ->call('updatePassword')
+            ->assertHasErrors(['current_password']);
 
-    public function test_new_passwords_must_match()
-    {
-        $this->actingAs($user = User::factory()->create());
+    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+});
 
-        Livewire::test(UpdatePasswordForm::class)
-                ->set('state', [
-                    'current_password' => 'password',
-                    'password' => 'new-password',
-                    'password_confirmation' => 'wrong-password',
-                ])
-                ->call('updatePassword')
-                ->assertHasErrors(['password']);
+test('new passwords must match', function () {
+    $this->actingAs($user = User::factory()->create());
 
-        $this->assertTrue(Hash::check('password', $user->fresh()->password));
-    }
-}
+    Livewire::test(UpdatePasswordForm::class)
+            ->set('state', [
+                'current_password' => 'password',
+                'password' => 'new-password',
+                'password_confirmation' => 'wrong-password',
+            ])
+            ->call('updatePassword')
+            ->assertHasErrors(['password']);
+
+    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+});

--- a/tests/Feature/JetStream/UpdatePasswordTest.php
+++ b/tests/Feature/JetStream/UpdatePasswordTest.php
@@ -19,7 +19,7 @@ test('password can be updated', function () {
             ])
             ->call('updatePassword');
 
-    $this->assertTrue(Hash::check('new-password', $user->fresh()->password));
+    expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
 });
 
 test('current password must be correct', function () {
@@ -34,7 +34,7 @@ test('current password must be correct', function () {
             ->call('updatePassword')
             ->assertHasErrors(['current_password']);
 
-    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+    expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
 });
 
 test('new passwords must match', function () {
@@ -49,5 +49,5 @@ test('new passwords must match', function () {
             ->call('updatePassword')
             ->assertHasErrors(['password']);
 
-    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+    expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
 });

--- a/tests/Feature/JetStream/UpdatePasswordTest.php
+++ b/tests/Feature/JetStream/UpdatePasswordTest.php
@@ -6,7 +6,6 @@ use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 test('password can be updated', function () {
     $this->actingAs($user = User::factory()->create());

--- a/tests/Feature/Jobs/ImportYoutubeChannelStreamsJobTest.php
+++ b/tests/Feature/Jobs/ImportYoutubeChannelStreamsJobTest.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-uses(TestCase::class);
 uses(YouTubeResponses::class);
 
 it('imports youtube channel streams', function () {

--- a/tests/Feature/Jobs/ImportYoutubeChannelStreamsJobTest.php
+++ b/tests/Feature/Jobs/ImportYoutubeChannelStreamsJobTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Jobs;
-
 use App\Jobs\ImportYoutubeChannelStreamsJob;
 use App\Models\Channel;
 use App\Models\Stream;
@@ -9,76 +7,68 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-class ImportYoutubeChannelStreamsJobTest extends TestCase
-{
-    use YouTubeResponses;
+uses(TestCase::class);
+uses(YouTubeResponses::class);
 
-    /** @test */
-    public function it_imports_youtube_channel_streams(): void
-    {
-        Http::fake([
-            '*search*' => Http::response($this->upcomingStreamsResponse()),
-            '*video*' => Http::response($this->videoResponse()),
-        ]);
+it('imports youtube channel streams', function () {
+    Http::fake([
+        '*search*' => Http::response($this->upcomingStreamsResponse()),
+        '*video*' => Http::response($this->videoResponse()),
+    ]);
 
-        // Assert
-        $this->assertDatabaseCount(Stream::class, 0);
+    // Assert
+    $this->assertDatabaseCount(Stream::class, 0);
 
-        // Act
-        (new ImportYoutubeChannelStreamsJob('UCdtd5QYBx9MUVXHm7qgEpxA', 'en'))->handle();
+    // Act
+    (new ImportYoutubeChannelStreamsJob('UCdtd5QYBx9MUVXHm7qgEpxA', 'en'))->handle();
 
-        // Assert
-        $this->assertDatabaseCount(Stream::class, 3);
-        $this->assertDatabaseHas(Stream::class, [
-            'youtube_id' => 'gzqJZQyfkaI',
-            'language_code' => 'en',
-        ]);
+    // Assert
+    $this->assertDatabaseCount(Stream::class, 3);
+    $this->assertDatabaseHas(Stream::class, [
+        'youtube_id' => 'gzqJZQyfkaI',
+        'language_code' => 'en',
+    ]);
 
-        $stream = Stream::first();
-        $this->assertNotNull($stream->approved_at);
-    }
+    $stream = Stream::first();
+    $this->assertNotNull($stream->approved_at);
+});
 
-    /** @test */
-    public function it_sets_channel_id_to_new_streams(): void
-    {
-        // Arrange
-        Http::fake([
-            '*search*' => Http::response($this->upcomingStreamsResponse()),
-            '*video*' => Http::response($this->videoResponse()),
-        ]);
+it('sets channel id to new streams', function () {
+    // Arrange
+    Http::fake([
+        '*search*' => Http::response($this->upcomingStreamsResponse()),
+        '*video*' => Http::response($this->videoResponse()),
+    ]);
 
-        $channel = Channel::factory()->create(['platform_id' => 'UCNlUCA4VORBx8X-h-rXvXEg']);
+    $channel = Channel::factory()->create(['platform_id' => 'UCNlUCA4VORBx8X-h-rXvXEg']);
 
-        // Assert
-        $this->assertDatabaseCount(Stream::class, 0);
+    // Assert
+    $this->assertDatabaseCount(Stream::class, 0);
 
-        // Act
-        (new ImportYoutubeChannelStreamsJob('UCNlUCA4VORBx8X-h-rXvXEg', 'en'))->handle();
+    // Act
+    (new ImportYoutubeChannelStreamsJob('UCNlUCA4VORBx8X-h-rXvXEg', 'en'))->handle();
 
-        // Assert
-        $this->assertDatabaseCount(Stream::class, 3);
-        $this->assertDatabaseHas(Stream::class, [
-            'channel_id' => $channel->id,
-        ]);
+    // Assert
+    $this->assertDatabaseCount(Stream::class, 3);
+    $this->assertDatabaseHas(Stream::class, [
+        'channel_id' => $channel->id,
+    ]);
 
-        $stream = Stream::first();
-        $this->assertNotNull($stream->approved_at);
-    }
+    $stream = Stream::first();
+    $this->assertNotNull($stream->approved_at);
+});
 
-    /** @test */
-    public function it_updates_already_given_streams(): void
-    {
-        // Arrange
-        Http::fake([
-            '*search*' => Http::response($this->upcomingStreamsResponse()),
-            '*video*' => Http::response($this->videoResponse()),
-        ]);
-        Stream::factory()->create(['youtube_id' => 'gzqJZQyfkaI']);
+it('updates already given streams', function () {
+    // Arrange
+    Http::fake([
+        '*search*' => Http::response($this->upcomingStreamsResponse()),
+        '*video*' => Http::response($this->videoResponse()),
+    ]);
+    Stream::factory()->create(['youtube_id' => 'gzqJZQyfkaI']);
 
-        // Act
-        (new ImportYoutubeChannelStreamsJob('UCdtd5QYBx9MUVXHm7qgEpxA', 'en'))->handle();
+    // Act
+    (new ImportYoutubeChannelStreamsJob('UCdtd5QYBx9MUVXHm7qgEpxA', 'en'))->handle();
 
-        // Assert
-        $this->assertDatabaseCount(Stream::class, 3);
-    }
-}
+    // Assert
+    $this->assertDatabaseCount(Stream::class, 3);
+});

--- a/tests/Feature/Models/StreamTest.php
+++ b/tests/Feature/Models/StreamTest.php
@@ -15,7 +15,7 @@ it('only gives approved streams', function () {
     $streams = Stream::approved()->get();
 
     // Assert
-    $this->assertCount(1, $streams);
+    expect($streams)->toHaveCount(1);
 });
 
 it('gets next upcoming stream', function () {
@@ -32,7 +32,7 @@ it('gets next upcoming stream', function () {
     $actualStream = Stream::getNextUpcomingOrLive();
 
     // Assert
-    $this->assertEquals($expectedStream->id, $actualStream->id);
+    expect($actualStream->id)->toEqual($expectedStream->id);
 });
 
 it('gets next live stream before upcoming', function () {
@@ -49,5 +49,5 @@ it('gets next live stream before upcoming', function () {
     $actualStream = Stream::getNextUpcomingOrLive();
 
     // Assert
-    $this->assertEquals($expectedStream->id, $actualStream->id);
+    expect($actualStream->id)->toEqual($expectedStream->id);
 });

--- a/tests/Feature/Models/StreamTest.php
+++ b/tests/Feature/Models/StreamTest.php
@@ -1,62 +1,53 @@
 <?php
 
-namespace Tests\Feature\Models;
-
 use App\Models\Stream;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-class StreamTest extends TestCase
-{
-    /** @test */
-    public function it_only_gives_approved_streams(): void
-    {
-        // Arrange
-        Stream::factory()->notApproved()->create();
-        Stream::factory()->approved()->create();
+uses(TestCase::class);
 
-        // Act
-        $streams = Stream::approved()->get();
+it('only gives approved streams', function () {
+    // Arrange
+    Stream::factory()->notApproved()->create();
+    Stream::factory()->approved()->create();
 
-        // Assert
-        $this->assertCount(1, $streams);
-    }
+    // Act
+    $streams = Stream::approved()->get();
 
-    /** @test */
-    public function it_gets_next_upcoming_stream(): void
-    {
-        // Arrange
-        Stream::factory()
-            ->upcoming()
-            ->create(['scheduled_start_time' => Carbon::tomorrow()->addDay()]);
+    // Assert
+    $this->assertCount(1, $streams);
+});
 
-        $expectedStream = Stream::factory()
-            ->upcoming()
-            ->create(['scheduled_start_time' => Carbon::tomorrow()]);
+it('gets next upcoming stream', function () {
+    // Arrange
+    Stream::factory()
+        ->upcoming()
+        ->create(['scheduled_start_time' => Carbon::tomorrow()->addDay()]);
 
-        // Act
-        $actualStream = Stream::getNextUpcomingOrLive();
+    $expectedStream = Stream::factory()
+        ->upcoming()
+        ->create(['scheduled_start_time' => Carbon::tomorrow()]);
 
-        // Assert
-        $this->assertEquals($expectedStream->id, $actualStream->id);
-    }
+    // Act
+    $actualStream = Stream::getNextUpcomingOrLive();
 
-    /** @test */
-    public function it_gets_next_live_stream_before_upcoming(): void
-    {
-        // Arrange
-        Stream::factory()
-            ->upcoming()
-            ->create(['scheduled_start_time' => Carbon::tomorrow()->addDay()]);
+    // Assert
+    $this->assertEquals($expectedStream->id, $actualStream->id);
+});
 
-        $expectedStream = Stream::factory()
-            ->live()
-            ->create(['scheduled_start_time' => Carbon::tomorrow()]);
+it('gets next live stream before upcoming', function () {
+    // Arrange
+    Stream::factory()
+        ->upcoming()
+        ->create(['scheduled_start_time' => Carbon::tomorrow()->addDay()]);
 
-        // Act
-        $actualStream = Stream::getNextUpcomingOrLive();
+    $expectedStream = Stream::factory()
+        ->live()
+        ->create(['scheduled_start_time' => Carbon::tomorrow()]);
 
-        // Assert
-        $this->assertEquals($expectedStream->id, $actualStream->id);
-    }
-}
+    // Act
+    $actualStream = Stream::getNextUpcomingOrLive();
+
+    // Assert
+    $this->assertEquals($expectedStream->id, $actualStream->id);
+});

--- a/tests/Feature/Models/StreamTest.php
+++ b/tests/Feature/Models/StreamTest.php
@@ -4,7 +4,6 @@ use App\Models\Stream;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('only gives approved streams', function () {
     // Arrange

--- a/tests/Feature/PageArchiveTest.php
+++ b/tests/Feature/PageArchiveTest.php
@@ -1,160 +1,141 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Channel;
 use App\Models\Stream;
 use Carbon\Carbon;
 use Tests\TestCase;
 use Vinkla\Hashids\Facades\Hashids;
 
-class PageArchiveTest extends TestCase
-{
-    /** @test */
-    public function it_shows_only_finished_streams(): void
-    {
-        // Arrange
-        Stream::factory()->withChannel()->finished()->create(['title' => 'Finished stream']);
-        Stream::factory()->withChannel()->live()->create(['title' => 'Live stream']);
-        Stream::factory()->withChannel()->upcoming()->create(['title' => 'Upcoming stream']);
+uses(TestCase::class);
 
-        // Act & Assert
-        $this->get(route('archive'))
-            ->assertDontSee('Live stream')
-            ->assertDontSee('Upcoming stream')
-            ->assertSee('Finished stream');
-    }
+it('shows only finished streams', function () {
+    // Arrange
+    Stream::factory()->withChannel()->finished()->create(['title' => 'Finished stream']);
+    Stream::factory()->withChannel()->live()->create(['title' => 'Live stream']);
+    Stream::factory()->withChannel()->upcoming()->create(['title' => 'Upcoming stream']);
 
-    /** @test */
-    public function it_orders_streams_from_latest_to_oldest(): void
-    {
-        // Arrange
-        Stream::factory()->withChannel()->finished()->create(['title' => 'Finished one day ago', 'scheduled_start_time' => Carbon::yesterday()]);
-        Stream::factory()->withChannel()->finished()->create(['title' => 'Finished two days ago', 'scheduled_start_time' => Carbon::yesterday()->subDay()]);
-        Stream::factory()->withChannel()->finished()->create(['title' => 'Finished three days ago', 'scheduled_start_time' => Carbon::yesterday()->subDays(2)]);
+    // Act & Assert
+    $this->get(route('archive'))
+        ->assertDontSee('Live stream')
+        ->assertDontSee('Upcoming stream')
+        ->assertSee('Finished stream');
+});
 
-        // Act & Assert
-        $this->get(route('archive'))
-            ->assertSeeInOrder([
-                'Finished one day ago',
-                'Finished two days ago',
-                'Finished three days ago',
-            ]);
-    }
+it('orders streams from latest to oldest', function () {
+    // Arrange
+    Stream::factory()->withChannel()->finished()->create(['title' => 'Finished one day ago', 'scheduled_start_time' => Carbon::yesterday()]);
+    Stream::factory()->withChannel()->finished()->create(['title' => 'Finished two days ago', 'scheduled_start_time' => Carbon::yesterday()->subDay()]);
+    Stream::factory()->withChannel()->finished()->create(['title' => 'Finished three days ago', 'scheduled_start_time' => Carbon::yesterday()->subDays(2)]);
 
-    /** @test */
-    public function it_does_not_show_deleted_streams(): void
-    {
-        // Arrange
-        Stream::factory()
-            ->withChannel()
-            ->deleted()
-            ->create(['title' => 'Stream deleted']);
+    // Act & Assert
+    $this->get(route('archive'))
+        ->assertSeeInOrder([
+            'Finished one day ago',
+            'Finished two days ago',
+            'Finished three days ago',
+        ]);
+});
 
-        Stream::factory()
-            ->withChannel()
-            ->finished()
-            ->create(['title' => 'Stream finished']);
+it('does not show deleted streams', function () {
+    // Arrange
+    Stream::factory()
+        ->withChannel()
+        ->deleted()
+        ->create(['title' => 'Stream deleted']);
 
-        // Act & Assert
-        $this
-            ->get(route('archive'))
-            ->assertSee('Stream finished')
-            ->assertDontSee('Stream deleted');
-    }
+    Stream::factory()
+        ->withChannel()
+        ->finished()
+        ->create(['title' => 'Stream finished']);
 
-    /** @test */
-    public function it_shows_duration_of_stream_if_given(): void
-    {
-        // Arrange
-        Stream::factory()
-            ->withChannel()
-            ->finished()
-            ->create([
-                'actual_start_time' => Carbon::yesterday(),
-                'actual_end_time' => Carbon::yesterday()->addHour()->addMinutes(12),
-            ]);
+    // Act & Assert
+    $this
+        ->get(route('archive'))
+        ->assertSee('Stream finished')
+        ->assertDontSee('Stream deleted');
+});
 
-        // Act & Assert
-        $this
-            ->get(route('archive'))
-            ->assertSee('1h 12m');
-    }
+it('shows duration of stream if given', function () {
+    // Arrange
+    Stream::factory()
+        ->withChannel()
+        ->finished()
+        ->create([
+            'actual_start_time' => Carbon::yesterday(),
+            'actual_end_time' => Carbon::yesterday()->addHour()->addMinutes(12),
+        ]);
 
-    /** @test */
-    public function it_searches_for_streams_on_title(): void
-    {
-        // Arrange
-        Stream::factory()->withChannel()->finished()->create(['title' => 'Stream One']);
-        Stream::factory()->withChannel()->finished()->create(['title' => 'Stream Two']);
-        Stream::factory()->withChannel()->finished()->create(['title' => 'Stream Three']);
+    // Act & Assert
+    $this
+        ->get(route('archive'))
+        ->assertSee('1h 12m');
+});
 
-        // Act & Assert
-        $this->get(route('archive', ['search' => 'three']))
-            ->assertSee([
-                'Stream Three',
-            ])->assertDontSee([
-                'Stream One',
-                'Stream Two',
-            ]);
-    }
+it('searches for streams on title', function () {
+    // Arrange
+    Stream::factory()->withChannel()->finished()->create(['title' => 'Stream One']);
+    Stream::factory()->withChannel()->finished()->create(['title' => 'Stream Two']);
+    Stream::factory()->withChannel()->finished()->create(['title' => 'Stream Three']);
 
-    /** @test */
-    public function it_searches_for_streams_on_channel_title(): void
-    {
-        // Arrange
-        $channelShown = Channel::factory()->create(['name' => 'Channel Shown']);
-        Stream::factory()
-            ->finished()
-            ->for($channelShown)
-            ->create(['title' => 'Stream Shown #1']);
+    // Act & Assert
+    $this->get(route('archive', ['search' => 'three']))
+        ->assertSee([
+            'Stream Three',
+        ])->assertDontSee([
+            'Stream One',
+            'Stream Two',
+        ]);
+});
 
-        Stream::factory()
-            ->finished()
-            ->for($channelShown)
-            ->create(['title' => 'Stream Shown #2']);
+it('searches for streams on channel title', function () {
+    // Arrange
+    $channelShown = Channel::factory()->create(['name' => 'Channel Shown']);
+    Stream::factory()
+        ->finished()
+        ->for($channelShown)
+        ->create(['title' => 'Stream Shown #1']);
 
-        Stream::factory()
-            ->finished()
-            ->for(Channel::factory()->create(['name' => 'Channel Hidden']))
-            ->create(['title' => 'Stream Hidden']);
+    Stream::factory()
+        ->finished()
+        ->for($channelShown)
+        ->create(['title' => 'Stream Shown #2']);
 
-        // Act & Assert
-        $this->get(route('archive', ['search' => 'Channel Shown']))
-            ->assertSee([
-                'Stream Shown #1',
-                'Stream Shown #2',
-                'Channel Shown',
-            ])
-            ->assertDontSee([
-                'Stream Hidden',
-            ]);
-    }
+    Stream::factory()
+        ->finished()
+        ->for(Channel::factory()->create(['name' => 'Channel Hidden']))
+        ->create(['title' => 'Stream Hidden']);
 
-    /** @test */
-    public function it_searches_for_streams_by_specific_streamer(): void
-    {
-        // Arrange
-        Stream::factory()->withChannel()->finished()->create(['title' => 'Stream Shown']);
-        Stream::factory()->withChannel()->finished()->create(['title' => 'Stream Hidden']);
+    // Act & Assert
+    $this->get(route('archive', ['search' => 'Channel Shown']))
+        ->assertSee([
+            'Stream Shown #1',
+            'Stream Shown #2',
+            'Channel Shown',
+        ])
+        ->assertDontSee([
+            'Stream Hidden',
+        ]);
+});
 
-        // Act & Assert
-        $this->get(route('archive', ['streamer' => Hashids::encode(1)]))
-            ->assertSee('Stream Shown')
-            ->assertDontSee('Stream Hidden');
-    }
+it('searches for streams by specific streamer', function () {
+    // Arrange
+    Stream::factory()->withChannel()->finished()->create(['title' => 'Stream Shown']);
+    Stream::factory()->withChannel()->finished()->create(['title' => 'Stream Hidden']);
 
-    /** @test */
-    public function it_searches_for_streams_by_specific_streamer_and_search_term(): void
-    {
-        // Arrange
-        $channel = Channel::factory()->create();
-        Stream::factory()->for($channel)->finished()->create(['title' => 'Stream Shown']);
-        Stream::factory()->for($channel)->finished()->create(['title' => 'Stream Hidden']);
+    // Act & Assert
+    $this->get(route('archive', ['streamer' => Hashids::encode(1)]))
+        ->assertSee('Stream Shown')
+        ->assertDontSee('Stream Hidden');
+});
 
-        // Act & Assert
-        $this->get(route('archive', ['streamer' => '1', 'search' => 'Shown']))
-            ->assertSee('Stream Shown')
-            ->assertDontSee('Stream Hidden');
-    }
-}
+it('searches for streams by specific streamer and search term', function () {
+    // Arrange
+    $channel = Channel::factory()->create();
+    Stream::factory()->for($channel)->finished()->create(['title' => 'Stream Shown']);
+    Stream::factory()->for($channel)->finished()->create(['title' => 'Stream Hidden']);
+
+    // Act & Assert
+    $this->get(route('archive', ['streamer' => '1', 'search' => 'Shown']))
+        ->assertSee('Stream Shown')
+        ->assertDontSee('Stream Hidden');
+});

--- a/tests/Feature/PageArchiveTest.php
+++ b/tests/Feature/PageArchiveTest.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use Tests\TestCase;
 use Vinkla\Hashids\Facades\Hashids;
 
-uses(TestCase::class);
 
 it('shows only finished streams', function () {
     // Arrange

--- a/tests/Feature/PageDashboardTest.php
+++ b/tests/Feature/PageDashboardTest.php
@@ -5,7 +5,6 @@ use App\Http\Livewire\ImportYouTubeLiveStream;
 use App\Models\User;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('includes livewire youtube import stream component', function () {
     $this->actingAs(User::factory()->create())

--- a/tests/Feature/PageDashboardTest.php
+++ b/tests/Feature/PageDashboardTest.php
@@ -1,27 +1,20 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Http\Livewire\ImportYouTubeChannel;
 use App\Http\Livewire\ImportYouTubeLiveStream;
 use App\Models\User;
 use Tests\TestCase;
 
-class PageDashboardTest extends TestCase
-{
-    /** @test */
-    public function it_includes_livewire_youtube_import_stream_component(): void
-    {
-        $this->actingAs(User::factory()->create())
-            ->get(route('dashboard'))
-            ->assertSeeLivewire(ImportYouTubeLiveStream::class);
-    }
+uses(TestCase::class);
 
-    /** @test */
-    public function it_includes_livewire_youtube_import_channel_component(): void
-    {
-        $this->actingAs(User::factory()->create())
-            ->get(route('dashboard'))
-            ->assertSeeLivewire(ImportYouTubeChannel::class);
-    }
-}
+it('includes livewire youtube import stream component', function () {
+    $this->actingAs(User::factory()->create())
+        ->get(route('dashboard'))
+        ->assertSeeLivewire(ImportYouTubeLiveStream::class);
+});
+
+it('includes livewire youtube import channel component', function () {
+    $this->actingAs(User::factory()->create())
+        ->get(route('dashboard'))
+        ->assertSeeLivewire(ImportYouTubeChannel::class);
+});

--- a/tests/Feature/PageHomeTest.php
+++ b/tests/Feature/PageHomeTest.php
@@ -1,148 +1,127 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Channel;
 use App\Models\Stream;
 use App\Services\YouTube\StreamData;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-class PageHomeTest extends TestCase
-{
-    /** @test */
-    public function it_shows_given_streams_on_home_page(): void
-    {
-        // Arrange
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #1', 'scheduled_start_time' => Carbon::now()->addDays(), 'youtube_id' => '1234', 'language_code' => 'en']);
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #2', 'scheduled_start_time' => Carbon::now()->addDays(2), 'youtube_id' => '12345', 'language_code' => 'fr']);
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #3', 'scheduled_start_time' => Carbon::now()->addDays(3), 'youtube_id' => '123456', 'language_code' => 'es']);
+uses(TestCase::class);
 
-        // Act & Assert
-        $this->get(route('home'))
-            ->assertSee('Stream #1')
-            ->assertSee('https://www.youtube.com/watch?v=1234')
-            ->assertSee('My Channel')
-            ->assertSee('Stream #2')
-            ->assertSee('French')
-            ->assertSee('https://www.youtube.com/watch?v=12345')
-            ->assertSee('Stream #3')
-            ->assertSee('Spanish')
-            ->assertSee('https://www.youtube.com/watch?v=123456');
-    }
+it('shows given streams on home page', function () {
+    // Arrange
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #1', 'scheduled_start_time' => Carbon::now()->addDays(), 'youtube_id' => '1234', 'language_code' => 'en']);
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #2', 'scheduled_start_time' => Carbon::now()->addDays(2), 'youtube_id' => '12345', 'language_code' => 'fr']);
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #3', 'scheduled_start_time' => Carbon::now()->addDays(3), 'youtube_id' => '123456', 'language_code' => 'es']);
 
-    /** @test */
-    public function it_shows_from_closest_to_farthest(): void
-    {
-        // Arrange
-        Stream::factory()
-            ->withChannel()
-            ->create(['title' => 'Stream #1', 'scheduled_start_time' => Carbon::tomorrow()]);
-        Stream::factory()
-            ->withChannel()
-            ->create(['title' => 'Stream #2', 'scheduled_start_time' => Carbon::tomorrow()->addDay()]);
-        Stream::factory()
-            ->withChannel()
-            ->create(['title' => 'Stream #3', 'scheduled_start_time' => Carbon::tomorrow()->addDays(2)]);
+    // Act & Assert
+    $this->get(route('home'))
+        ->assertSee('Stream #1')
+        ->assertSee('https://www.youtube.com/watch?v=1234')
+        ->assertSee('My Channel')
+        ->assertSee('Stream #2')
+        ->assertSee('French')
+        ->assertSee('https://www.youtube.com/watch?v=12345')
+        ->assertSee('Stream #3')
+        ->assertSee('Spanish')
+        ->assertSee('https://www.youtube.com/watch?v=123456');
+});
 
-        // Act & Assert
-        $this->get(route('home'))
-            ->assertSeeInOrder(['Stream #1', 'Stream #2', 'Stream #3']);
-    }
+it('shows from closest to farthest', function () {
+    // Arrange
+    Stream::factory()
+        ->withChannel()
+        ->create(['title' => 'Stream #1', 'scheduled_start_time' => Carbon::tomorrow()]);
+    Stream::factory()
+        ->withChannel()
+        ->create(['title' => 'Stream #2', 'scheduled_start_time' => Carbon::tomorrow()->addDay()]);
+    Stream::factory()
+        ->withChannel()
+        ->create(['title' => 'Stream #3', 'scheduled_start_time' => Carbon::tomorrow()->addDays(2)]);
 
-    /** @test */
-    public function it_shows_unique_names_for_today_and_tomorrow_instead_of_whole_date(): void
-    {
-        $this->withoutExceptionHandling();
-        // Arrange
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #1', 'scheduled_start_time' => Carbon::today()->hour(2)]);
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #2', 'scheduled_start_time' => Carbon::tomorrow()]);
+    // Act & Assert
+    $this->get(route('home'))
+        ->assertSeeInOrder(['Stream #1', 'Stream #2', 'Stream #3']);
+});
 
-        // Act & Assert
-        $this->get(route('home'))
-            ->assertDontSee(today()->format('D d.m.Y'))
-            ->assertSee('Today')
-            ->assertDontSee(Carbon::tomorrow()->format('D d.m.Y'))
-            ->assertSee('Tomorrow');
-    }
+it('shows unique names for today and tomorrow instead of whole date', function () {
+    $this->withoutExceptionHandling();
+    // Arrange
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #1', 'scheduled_start_time' => Carbon::today()->hour(2)]);
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->create(['title' => 'Stream #2', 'scheduled_start_time' => Carbon::tomorrow()]);
 
-    /** @test */
-    public function it_does_not_show_old_streams(): void
-    {
-        // Arrange
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->finished()->create(['title' => 'Stream finished']);
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->live()->create(['title' => 'Stream live']);
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->upcoming()->create(['title' => 'Stream upcoming']);
+    // Act & Assert
+    $this->get(route('home'))
+        ->assertDontSee(today()->format('D d.m.Y'))
+        ->assertSee('Today')
+        ->assertDontSee(Carbon::tomorrow()->format('D d.m.Y'))
+        ->assertSee('Tomorrow');
+});
 
-        // Act & Assert
-        $this
-            ->get(route('home'))
-            ->assertSee('Stream live')
-            ->assertSee('Stream upcoming')
-                ->assertDontSee('Stream finished');
-    }
+it('does not show old streams', function () {
+    // Arrange
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->finished()->create(['title' => 'Stream finished']);
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->live()->create(['title' => 'Stream live']);
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->upcoming()->create(['title' => 'Stream upcoming']);
 
-    /** @test */
-    public function it_does_not_show_deleted_streams(): void
-    {
-        // Arrange
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->deleted()->create(['title' => 'Stream deleted']);
-        Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->upcoming()->create(['title' => 'Stream upcoming']);
+    // Act & Assert
+    $this
+        ->get(route('home'))
+        ->assertSee('Stream live')
+        ->assertSee('Stream upcoming')
+            ->assertDontSee('Stream finished');
+});
 
-        // Act & Assert
-        $this
-            ->get(route('home'))
-            ->assertSee('Stream upcoming')
-            ->assertDontSee('Stream deleted');
-    }
+it('does not show deleted streams', function () {
+    // Arrange
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->deleted()->create(['title' => 'Stream deleted']);
+    Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->upcoming()->create(['title' => 'Stream upcoming']);
 
-    /** @test */
-    public function it_marks_live_streams(): void
-    {
-        // Arrange
-        $stream = Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->upcoming()->create(['title' => 'Stream #1']);
+    // Act & Assert
+    $this
+        ->get(route('home'))
+        ->assertSee('Stream upcoming')
+        ->assertDontSee('Stream deleted');
+});
 
-        // Act & Assert
-        $this->get(route('home'))
-            ->assertSee('Stream #1')
-            ->assertDontSee('>live</span>', false);
+it('marks live streams', function () {
+    // Arrange
+    $stream = Stream::factory()->for(Channel::factory()->create(['name' => 'My Channel']))->upcoming()->create(['title' => 'Stream #1']);
 
-        $stream->update(['status' => StreamData::STATUS_LIVE]);
+    // Act & Assert
+    $this->get(route('home'))
+        ->assertSee('Stream #1')
+        ->assertDontSee('>live</span>', false);
 
-        $this->get(route('home'))
-             ->assertSee('Stream #1')
-             ->assertSee('>live</span>', false);
-    }
+    $stream->update(['status' => StreamData::STATUS_LIVE]);
 
-    /** @test */
-    public function it_shows_footer_links(): void
-    {
-        // Arrange
-        $twitterLink = 'https://twitter.com/larastreamers';
-        $githubLink = 'https://github.com/christophrumpel/larastreamers';
+    $this->get(route('home'))
+         ->assertSee('Stream #1')
+         ->assertSee('>live</span>', false);
+});
 
-        // Act & Assert
-        $this->get(route('home'))
-            ->assertSee($twitterLink)
-            ->assertSee($githubLink);
-    }
+it('shows footer links', function () {
+    // Arrange
+    $twitterLink = 'https://twitter.com/larastreamers';
+    $githubLink = 'https://github.com/christophrumpel/larastreamers';
 
-    /** @test */
-    public function it_adds_not_button_webcal_link_if_no_streams(): void
-    {
-        $this->get(route('home'))
-            ->assertDontSee('webcal://');
-    }
+    // Act & Assert
+    $this->get(route('home'))
+        ->assertSee($twitterLink)
+        ->assertSee($githubLink);
+});
 
-    /** @test */
-    public function it_adds_button_webcal_link_if_no_streams(): void
-    {
-        Stream::factory()
-            ->for(Channel::factory()->create(['name' => 'My Channel']))
-            ->upcoming()
-            ->create();
+it('adds not button webcal link if no streams', function () {
+    $this->get(route('home'))
+        ->assertDontSee('webcal://');
+});
 
-        $this->get(route('home'))
-            ->assertSee('webcal://');
-    }
-}
+it('adds button webcal link if no streams', function () {
+    Stream::factory()
+        ->for(Channel::factory()->create(['name' => 'My Channel']))
+        ->upcoming()
+        ->create();
+
+    $this->get(route('home'))
+        ->assertSee('webcal://');
+});

--- a/tests/Feature/PageHomeTest.php
+++ b/tests/Feature/PageHomeTest.php
@@ -6,7 +6,6 @@ use App\Services\YouTube\StreamData;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('shows given streams on home page', function () {
     // Arrange

--- a/tests/Feature/PageStreamersTest.php
+++ b/tests/Feature/PageStreamersTest.php
@@ -1,153 +1,139 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Channel;
 use App\Models\Stream;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
-class PageStreamersTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function it_shows_channel_data(): void
-    {
-        // Arrange
-        $channel = Channel::factory()
-            ->has(Stream::factory()->approved()->finished())
-            ->create(['name' => 'Channel Dries']);
+it('shows channel data', function () {
+    // Arrange
+    $channel = Channel::factory()
+        ->has(Stream::factory()->approved()->finished())
+        ->create(['name' => 'Channel Dries']);
 
-        // Act
-        $response = $this->get(route('streamers'));
+    // Act
+    $response = $this->get(route('streamers'));
 
-        // Assert
-        $response->assertSee([
-            $channel->name,
-            $channel->country,
-            Str::of($channel->description)->limit(100),
-            $channel->thumbnail_url,
-            "https://twitter.com/$channel->twitter_handle",
-            route('archive', ['streamer' => $channel->hashid]),
-        ]);
-    }
+    // Assert
+    $response->assertSee([
+        $channel->name,
+        $channel->country,
+        Str::of($channel->description)->limit(100),
+        $channel->thumbnail_url,
+        "https://twitter.com/$channel->twitter_handle",
+        route('archive', ['streamer' => $channel->hashid]),
+    ]);
+});
 
-    /** @test */
-    public function it_shows_all_streamers(): void
-    {
-        // Arrange
-        Channel::factory()
-            ->has(Stream::factory()->approved()->finished())
-            ->create(['name' => 'C Channel Dries']);
-        Channel::factory()
-            ->has(Stream::factory()->approved()->finished())
-            ->create(['name' => 'A Channel Mohamed']);
-        Channel::factory()
-            ->has(Stream::factory()->approved()->finished())
-            ->create(['name' => 'B Channel Steve']);
+it('shows all streamers', function () {
+    // Arrange
+    Channel::factory()
+        ->has(Stream::factory()->approved()->finished())
+        ->create(['name' => 'C Channel Dries']);
+    Channel::factory()
+        ->has(Stream::factory()->approved()->finished())
+        ->create(['name' => 'A Channel Mohamed']);
+    Channel::factory()
+        ->has(Stream::factory()->approved()->finished())
+        ->create(['name' => 'B Channel Steve']);
 
-        // Act
-        $response = $this->get(route('streamers'));
+    // Act
+    $response = $this->get(route('streamers'));
 
-        // Assert
-        $response->assertSee([
-            'A Channel Mohamed',
-            'B Channel Steve',
-            'C Channel Dries',
-        ]);
-    }
+    // Assert
+    $response->assertSee([
+        'A Channel Mohamed',
+        'B Channel Steve',
+        'C Channel Dries',
+    ]);
+});
 
-    /** @test */
-    public function it_only_shows_streamers_with_approved_and_finished_streams(): void
-    {
-        // Arrange
-        Stream::factory()
-            ->withChannel(['name' => 'Channel Hidden'])
-            ->finished()
-            ->notApproved()
-            ->create();
+it('only shows streamers with approved and finished streams', function () {
+    // Arrange
+    Stream::factory()
+        ->withChannel(['name' => 'Channel Hidden'])
+        ->finished()
+        ->notApproved()
+        ->create();
 
-        Stream::factory()
-            ->withChannel(['name' => 'Channel Shown'])
-            ->finished()
-            ->approved()
-            ->create();
+    Stream::factory()
+        ->withChannel(['name' => 'Channel Shown'])
+        ->finished()
+        ->approved()
+        ->create();
 
-        // Act
-        $response = $this->get(route('streamers'));
+    // Act
+    $response = $this->get(route('streamers'));
 
-        // Assert
-        $response
-            ->assertDontSee('Channel Hidden')
-            ->assertSee('Channel Shown');
-    }
+    // Assert
+    $response
+        ->assertDontSee('Channel Hidden')
+        ->assertSee('Channel Shown');
+});
 
-    /** @test */
-    public function it_shows_streamers_ordered_by_stream_count(): void
-    {
-        // Arrange
-        Stream::factory()
-            ->for(Channel::factory())
-            ->approved()
-            ->finished()
-            ->count(10)
-            ->create();
-        Stream::factory()
-            ->for(Channel::factory())
-            ->approved()
-            ->finished()
-            ->count(1)
-            ->create();
-        Stream::factory()
-            ->for(Channel::factory())
-            ->approved()
-            ->finished()
-            ->count(30)
-            ->create();
+it('shows streamers ordered by stream count', function () {
+    // Arrange
+    Stream::factory()
+        ->for(Channel::factory())
+        ->approved()
+        ->finished()
+        ->count(10)
+        ->create();
+    Stream::factory()
+        ->for(Channel::factory())
+        ->approved()
+        ->finished()
+        ->count(1)
+        ->create();
+    Stream::factory()
+        ->for(Channel::factory())
+        ->approved()
+        ->finished()
+        ->count(30)
+        ->create();
 
-        // Act
-        $response = $this->get(route('streamers'));
+    // Act
+    $response = $this->get(route('streamers'));
 
-        // Assert
-        $response->assertSeeText([
-            'Show 30 streams',
-            'Show 10 streams',
-            'Show 1 stream',
-        ]);
-    }
+    // Assert
+    $response->assertSeeText([
+        'Show 30 streams',
+        'Show 10 streams',
+        'Show 1 stream',
+    ]);
+});
 
-    /** @test */
-    public function it_only_counts_approved_and_finished_streams(): void
-    {
-        // Arrange
-        $channel = Channel::factory()->create();
-        Stream::factory()
-            ->approved()
-            ->finished()
-            ->for($channel)
-            ->count(10)
-            ->create();
+it('only counts approved and finished streams', function () {
+    // Arrange
+    $channel = Channel::factory()->create();
+    Stream::factory()
+        ->approved()
+        ->finished()
+        ->for($channel)
+        ->count(10)
+        ->create();
 
-        Stream::factory()
-            ->notApproved()
-            ->for($channel)
-            ->count(10)
-            ->create();
+    Stream::factory()
+        ->notApproved()
+        ->for($channel)
+        ->count(10)
+        ->create();
 
-        Stream::factory()
-            ->upcoming()
-            ->for($channel)
-            ->count(10)
-            ->create();
+    Stream::factory()
+        ->upcoming()
+        ->for($channel)
+        ->count(10)
+        ->create();
 
-        // Act
-        $response = $this->get(route('streamers'));
+    // Act
+    $response = $this->get(route('streamers'));
 
-        // Assert
-        $response->assertSeeInOrder([
-            'Show 10',
-        ]);
-    }
-}
+    // Assert
+    $response->assertSeeInOrder([
+        'Show 10',
+    ]);
+});

--- a/tests/Feature/PageStreamersTest.php
+++ b/tests/Feature/PageStreamersTest.php
@@ -6,7 +6,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
-uses(TestCase::class);
 uses(RefreshDatabase::class);
 
 it('shows channel data', function () {

--- a/tests/Feature/PagesResponseTest.php
+++ b/tests/Feature/PagesResponseTest.php
@@ -1,36 +1,25 @@
 <?php
 
-namespace Tests\Feature;
-
 use Tests\TestCase;
 
-class PagesResponseTest extends TestCase
-{
-    /** @test */
-    public function it_can_show_the_home_page(): void
-    {
-        $this->get(route('home'))
-             ->assertOk();
-    }
+uses(TestCase::class);
 
-    /** @test */
-    public function it_can_show_the_feed(): void
-    {
-        $this->get('/feed')
-            ->assertOk();
-    }
+it('can show the home page', function () {
+    $this->get(route('home'))
+         ->assertOk();
+});
 
-    /** @test */
-    public function it_can_show_the_archive(): void
-    {
-        $this->get(route('archive'))
-            ->assertOk();
-    }
+it('can show the feed', function () {
+    $this->get('/feed')
+        ->assertOk();
+});
 
-    /** @test */
-    public function it_can_show_the_calendar_page(): void
-    {
-        $this->get(route('calendar.ics'))
-            ->assertOk();
-    }
-}
+it('can show the archive', function () {
+    $this->get(route('archive'))
+        ->assertOk();
+});
+
+it('can show the calendar page', function () {
+    $this->get(route('calendar.ics'))
+        ->assertOk();
+});

--- a/tests/Feature/PagesResponseTest.php
+++ b/tests/Feature/PagesResponseTest.php
@@ -2,7 +2,6 @@
 
 use Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can show the home page', function () {
     $this->get(route('home'))

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/underlying-test-case */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/expectations#custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/helpers */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,9 @@
 <?php
 
+uses(\Tests\TestCase::class)->in('tests', 'Fakes', 'Feature', 'Unit');
+uses(\Tests\Fakes\YouTubeResponses::class)->in('Unit');
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class)->in('');
+
 /*
 |--------------------------------------------------------------------------
 | Test Case

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,7 @@ abstract class TestCase extends BaseTestCase
 
     private string $originalYoutubeApiKey;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/YouTubeTest.php
+++ b/tests/Unit/YouTubeTest.php
@@ -1,84 +1,74 @@
 <?php
 
-namespace Tests\Unit;
-
 use App\Facades\YouTube;
 use App\Services\YouTube\StreamData;
 use Illuminate\Support\Facades\Http;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-class YouTubeTest extends TestCase
-{
-    use YouTubeResponses;
+uses(TestCase::class);
+uses(YouTubeResponses::class);
 
-    /** @test */
-    public function it_can_fetch_channel_details_from_youtube(): void
-    {
-        // Arrange
-        Http::fake(fn() => Http::response($this->channelResponse()));
+it('can fetch channel details from youtube', function () {
+    // Arrange
+    Http::fake(fn() => Http::response($this->channelResponse()));
 
-        // Act
-        $channel = YouTube::channel('UCdtd5QYBx9MUVXHm7qgEpxA');
+    // Act
+    $channel = YouTube::channel('UCdtd5QYBx9MUVXHm7qgEpxA');
 
-        // Assert
-        $this->assertEquals('christophrumpel', $channel->youTubeCustomUrl);
-        $this->assertEquals('Christoph Rumpel', $channel->name);
-        $this->assertStringStartsWith('Hi, I\'m Christoph Rumpel', $channel->description);
-        $this->assertEquals('2010-01-12T19:15:29+00:00', $channel->onPlatformSince->toIso8601String());
-        $this->assertEquals('AT', $channel->country);
-        $this->assertEquals('https://yt3.ggpht.com/ytc/AAUvwniFZUkXnS4vDKY4lDohrpFsyu1V2AJwt4CFZGy25Q=s800-c-k-c0x00ffffff-no-rj', $channel->thumbnailUrl);
-    }
+    // Assert
+    $this->assertEquals('christophrumpel', $channel->youTubeCustomUrl);
+    $this->assertEquals('Christoph Rumpel', $channel->name);
+    $this->assertStringStartsWith('Hi, I\'m Christoph Rumpel', $channel->description);
+    $this->assertEquals('2010-01-12T19:15:29+00:00', $channel->onPlatformSince->toIso8601String());
+    $this->assertEquals('AT', $channel->country);
+    $this->assertEquals('https://yt3.ggpht.com/ytc/AAUvwniFZUkXnS4vDKY4lDohrpFsyu1V2AJwt4CFZGy25Q=s800-c-k-c0x00ffffff-no-rj', $channel->thumbnailUrl);
+});
 
-    /** @test */
-    public function it_can_fetch_upcoming_streams_from_youtube(): void
-    {
-        // Arrange
-        Http::fake([
-            '*search*' => Http::response($this->upcomingStreamsResponse()),
-            '*video*' => Http::response($this->videoResponse()),
-        ]);
+it('can fetch upcoming streams from youtube', function () {
+    // Arrange
+    Http::fake([
+        '*search*' => Http::response($this->upcomingStreamsResponse()),
+        '*video*' => Http::response($this->videoResponse()),
+    ]);
 
-        // Act
-        $streams = YouTube::upcomingStreams('UCNlUCA4VORBx8X-h-rXvXEg');
+    // Act
+    $streams = YouTube::upcomingStreams('UCNlUCA4VORBx8X-h-rXvXEg');
 
-        // Assert
-        $this->assertCount(3, $streams);
+    // Assert
+    $this->assertCount(3, $streams);
 
-        /** @var \App\Services\YouTube\StreamData $finishedStream */
-        $finishedStream = $streams->first();
+    /** @var \App\Services\YouTube\StreamData $finishedStream */
+    $finishedStream = $streams->first();
 
-        $this->assertEquals('gzqJZQyfkaI', $finishedStream->videoId);
-        $this->assertEquals('Live coding new features for larastreamers.com', $finishedStream->title);
-        $this->assertEquals("Christoph Rumpel created a nice new project: https://larastreamers.com/\nIn this stream, I'm going to add some features to Christoph's app.", $finishedStream->description);
-        $this->assertEquals('https://i.ytimg.com/vi/gzqJZQyfkaI/maxresdefault.jpg', $finishedStream->thumbnailUrl);
-        $this->assertEquals('2021-05-15T12:51:18+00:00', $finishedStream->publishedAt->toIso8601String());
-        $this->assertEquals('2031-05-15T11:00:00+00:00', $finishedStream->plannedStart->toIso8601String());
-        $this->assertEquals('2031-05-15T11:00:29+00:00', $finishedStream->actualStartTime->toIso8601String());
-        $this->assertEquals('2031-05-15T11:30:29+00:00', $finishedStream->actualEndTime->toIso8601String());
-        $this->assertEquals(StreamData::STATUS_FINISHED, $finishedStream->status);
+    $this->assertEquals('gzqJZQyfkaI', $finishedStream->videoId);
+    $this->assertEquals('Live coding new features for larastreamers.com', $finishedStream->title);
+    $this->assertEquals("Christoph Rumpel created a nice new project: https://larastreamers.com/\nIn this stream, I'm going to add some features to Christoph's app.", $finishedStream->description);
+    $this->assertEquals('https://i.ytimg.com/vi/gzqJZQyfkaI/maxresdefault.jpg', $finishedStream->thumbnailUrl);
+    $this->assertEquals('2021-05-15T12:51:18+00:00', $finishedStream->publishedAt->toIso8601String());
+    $this->assertEquals('2031-05-15T11:00:00+00:00', $finishedStream->plannedStart->toIso8601String());
+    $this->assertEquals('2031-05-15T11:00:29+00:00', $finishedStream->actualStartTime->toIso8601String());
+    $this->assertEquals('2031-05-15T11:30:29+00:00', $finishedStream->actualEndTime->toIso8601String());
+    $this->assertEquals(StreamData::STATUS_FINISHED, $finishedStream->status);
 
-        /** @var \App\Services\YouTube\StreamData $upcomingStream */
-        $upcomingStream = $streams->last();
+    /** @var \App\Services\YouTube\StreamData $upcomingStream */
+    $upcomingStream = $streams->last();
 
-        $this->assertEquals('L3O1BbybSgw', $upcomingStream->videoId);
-        $this->assertEquals('Casual Artisan Call #7', $upcomingStream->title);
-        $this->assertEquals('https://i.ytimg.com/vi/L3O1BbybSgw/maxresdefault_live.jpg', $upcomingStream->thumbnailUrl);
-        $this->assertEquals('2021-05-14T17:00:28+00:00', $upcomingStream->publishedAt->toIso8601String());
-        $this->assertEquals('2021-05-21T09:00:00+00:00', $upcomingStream->plannedStart->toIso8601String());
-        $this->assertNull($upcomingStream->actualStartTime);
-        $this->assertNull($upcomingStream->actualEndTime);
-        $this->assertEquals(StreamData::STATUS_UPCOMING, $upcomingStream->status);
-    }
+    $this->assertEquals('L3O1BbybSgw', $upcomingStream->videoId);
+    $this->assertEquals('Casual Artisan Call #7', $upcomingStream->title);
+    $this->assertEquals('https://i.ytimg.com/vi/L3O1BbybSgw/maxresdefault_live.jpg', $upcomingStream->thumbnailUrl);
+    $this->assertEquals('2021-05-14T17:00:28+00:00', $upcomingStream->publishedAt->toIso8601String());
+    $this->assertEquals('2021-05-21T09:00:00+00:00', $upcomingStream->plannedStart->toIso8601String());
+    $this->assertNull($upcomingStream->actualStartTime);
+    $this->assertNull($upcomingStream->actualEndTime);
+    $this->assertEquals(StreamData::STATUS_UPCOMING, $upcomingStream->status);
+});
 
-    /** @test */
-    public function it_uses_real_api_key_when_needed(): void
-    {
-        $this->assertEquals('FAKE-YOUTUBE-KEY', config()->get('services.youtube.key'));
+it('uses real api key when needed', function () {
+    $this->assertEquals('FAKE-YOUTUBE-KEY', config()->get('services.youtube.key'));
 
-        $this->useRealYoutubeApi();
+    $this->useRealYoutubeApi();
 
-        config()->set('services.youtube.key', 'REAL-API-KEY');
-        $this->assertEquals('REAL-API-KEY', config()->get('services.youtube.key'));
-    }
-}
+    config()->set('services.youtube.key', 'REAL-API-KEY');
+    $this->assertEquals('REAL-API-KEY', config()->get('services.youtube.key'));
+});

--- a/tests/Unit/YouTubeTest.php
+++ b/tests/Unit/YouTubeTest.php
@@ -6,8 +6,6 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fakes\YouTubeResponses;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(YouTubeResponses::class);
 
 it('can fetch channel details from youtube', function () {
     // Arrange

--- a/tests/Unit/YouTubeTest.php
+++ b/tests/Unit/YouTubeTest.php
@@ -17,12 +17,12 @@ it('can fetch channel details from youtube', function () {
     $channel = YouTube::channel('UCdtd5QYBx9MUVXHm7qgEpxA');
 
     // Assert
-    $this->assertEquals('christophrumpel', $channel->youTubeCustomUrl);
-    $this->assertEquals('Christoph Rumpel', $channel->name);
-    $this->assertStringStartsWith('Hi, I\'m Christoph Rumpel', $channel->description);
-    $this->assertEquals('2010-01-12T19:15:29+00:00', $channel->onPlatformSince->toIso8601String());
-    $this->assertEquals('AT', $channel->country);
-    $this->assertEquals('https://yt3.ggpht.com/ytc/AAUvwniFZUkXnS4vDKY4lDohrpFsyu1V2AJwt4CFZGy25Q=s800-c-k-c0x00ffffff-no-rj', $channel->thumbnailUrl);
+    expect($channel->youTubeCustomUrl)->toEqual('christophrumpel');
+    expect($channel->name)->toEqual('Christoph Rumpel');
+    expect($channel->description)->toStartWith('Hi, I\'m Christoph Rumpel');
+    expect($channel->onPlatformSince->toIso8601String())->toEqual('2010-01-12T19:15:29+00:00');
+    expect($channel->country)->toEqual('AT');
+    expect($channel->thumbnailUrl)->toEqual('https://yt3.ggpht.com/ytc/AAUvwniFZUkXnS4vDKY4lDohrpFsyu1V2AJwt4CFZGy25Q=s800-c-k-c0x00ffffff-no-rj');
 });
 
 it('can fetch upcoming streams from youtube', function () {
@@ -36,39 +36,39 @@ it('can fetch upcoming streams from youtube', function () {
     $streams = YouTube::upcomingStreams('UCNlUCA4VORBx8X-h-rXvXEg');
 
     // Assert
-    $this->assertCount(3, $streams);
+    expect($streams)->toHaveCount(3);
 
     /** @var \App\Services\YouTube\StreamData $finishedStream */
     $finishedStream = $streams->first();
 
-    $this->assertEquals('gzqJZQyfkaI', $finishedStream->videoId);
-    $this->assertEquals('Live coding new features for larastreamers.com', $finishedStream->title);
-    $this->assertEquals("Christoph Rumpel created a nice new project: https://larastreamers.com/\nIn this stream, I'm going to add some features to Christoph's app.", $finishedStream->description);
-    $this->assertEquals('https://i.ytimg.com/vi/gzqJZQyfkaI/maxresdefault.jpg', $finishedStream->thumbnailUrl);
-    $this->assertEquals('2021-05-15T12:51:18+00:00', $finishedStream->publishedAt->toIso8601String());
-    $this->assertEquals('2031-05-15T11:00:00+00:00', $finishedStream->plannedStart->toIso8601String());
-    $this->assertEquals('2031-05-15T11:00:29+00:00', $finishedStream->actualStartTime->toIso8601String());
-    $this->assertEquals('2031-05-15T11:30:29+00:00', $finishedStream->actualEndTime->toIso8601String());
-    $this->assertEquals(StreamData::STATUS_FINISHED, $finishedStream->status);
+    expect($finishedStream->videoId)->toEqual('gzqJZQyfkaI');
+    expect($finishedStream->title)->toEqual('Live coding new features for larastreamers.com');
+    expect($finishedStream->description)->toEqual("Christoph Rumpel created a nice new project: https://larastreamers.com/\nIn this stream, I'm going to add some features to Christoph's app.");
+    expect($finishedStream->thumbnailUrl)->toEqual('https://i.ytimg.com/vi/gzqJZQyfkaI/maxresdefault.jpg');
+    expect($finishedStream->publishedAt->toIso8601String())->toEqual('2021-05-15T12:51:18+00:00');
+    expect($finishedStream->plannedStart->toIso8601String())->toEqual('2031-05-15T11:00:00+00:00');
+    expect($finishedStream->actualStartTime->toIso8601String())->toEqual('2031-05-15T11:00:29+00:00');
+    expect($finishedStream->actualEndTime->toIso8601String())->toEqual('2031-05-15T11:30:29+00:00');
+    expect($finishedStream->status)->toEqual(StreamData::STATUS_FINISHED);
 
     /** @var \App\Services\YouTube\StreamData $upcomingStream */
     $upcomingStream = $streams->last();
 
-    $this->assertEquals('L3O1BbybSgw', $upcomingStream->videoId);
-    $this->assertEquals('Casual Artisan Call #7', $upcomingStream->title);
-    $this->assertEquals('https://i.ytimg.com/vi/L3O1BbybSgw/maxresdefault_live.jpg', $upcomingStream->thumbnailUrl);
-    $this->assertEquals('2021-05-14T17:00:28+00:00', $upcomingStream->publishedAt->toIso8601String());
-    $this->assertEquals('2021-05-21T09:00:00+00:00', $upcomingStream->plannedStart->toIso8601String());
-    $this->assertNull($upcomingStream->actualStartTime);
-    $this->assertNull($upcomingStream->actualEndTime);
-    $this->assertEquals(StreamData::STATUS_UPCOMING, $upcomingStream->status);
+    expect($upcomingStream->videoId)->toEqual('L3O1BbybSgw');
+    expect($upcomingStream->title)->toEqual('Casual Artisan Call #7');
+    expect($upcomingStream->thumbnailUrl)->toEqual('https://i.ytimg.com/vi/L3O1BbybSgw/maxresdefault_live.jpg');
+    expect($upcomingStream->publishedAt->toIso8601String())->toEqual('2021-05-14T17:00:28+00:00');
+    expect($upcomingStream->plannedStart->toIso8601String())->toEqual('2021-05-21T09:00:00+00:00');
+    expect($upcomingStream->actualStartTime)->toBeNull();
+    expect($upcomingStream->actualEndTime)->toBeNull();
+    expect($upcomingStream->status)->toEqual(StreamData::STATUS_UPCOMING);
 });
 
 it('uses real api key when needed', function () {
-    $this->assertEquals('FAKE-YOUTUBE-KEY', config()->get('services.youtube.key'));
+    expect(config()->get('services.youtube.key'))->toEqual('FAKE-YOUTUBE-KEY');
 
     $this->useRealYoutubeApi();
 
     config()->set('services.youtube.key', 'REAL-API-KEY');
-    $this->assertEquals('REAL-API-KEY', config()->get('services.youtube.key'));
+    expect(config()->get('services.youtube.key'))->toEqual('REAL-API-KEY');
 });


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-51942` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
